### PR TITLE
fix: add missing DoorbellMessageType IMAGE

### DIFF
--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -305,6 +305,7 @@ class DoorbellMessageType(str, ValuesEnumMixin, enum.Enum):
     LEAVE_PACKAGE_AT_DOOR = "LEAVE_PACKAGE_AT_DOOR"
     DO_NOT_DISTURB = "DO_NOT_DISTURB"
     CUSTOM_MESSAGE = "CUSTOM_MESSAGE"
+    IMAGE = "IMAGE"
 
 
 @enum.unique


### PR DESCRIPTION
### Description of change

Looking at the HA issue https://github.com/home-assistant/core/issues/117274, we can see that Protect 4.x introduced a new doorbell message type: `IMAGE` that's used if the user switches to a custom image/GIF on the G4 Doorbell Pro.
This PR adds the corresponding type to the enum, so the library can parse the UniFi JSON dict without failing completely.

Unfortunately, I don't have a G4 Doorbell Pro to test with and only made the change by looking at the HA issue. It's possible that we still fail later on because of other new settings we don't account for, but I don't think we *should*.
Still, this should be good-to-go as a first step IMO and also can't really break anything.

#### Note

The custom image feature should be implemented properly in future PRs. This PR just fixes the issue of "crashing" if the option is used.
That's also why I've not marked this as a "feat", as this doesn't introduce a new feature really. Feel free to update the title if wanted though.

### Pull-Request Checklist

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `IMAGE` message type in doorbell notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->