### PR TITLE
feat: avoid parsing last_update_id

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -16,7 +16,6 @@ from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
 from typing import Any, Literal, cast
 from urllib.parse import urljoin
-from uuid import UUID
 
 import aiofiles
 import aiohttp
@@ -647,7 +646,7 @@ class BaseApiClient:
     def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
         raise NotImplementedError
 
-    def _get_last_update_id(self) -> UUID | None:
+    def _get_last_update_id(self) -> str | None:
         raise NotImplementedError
 
 
@@ -833,7 +832,7 @@ class ProtectApiClient(BaseApiClient):
             except Exception:
                 _LOGGER.exception("Exception while running subscription handler")
 
-    def _get_last_update_id(self) -> UUID | None:
+    def _get_last_update_id(self) -> str | None:
         if self._bootstrap is None:
             return None
         return self._bootstrap.last_update_id

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, cast
-from uuid import UUID
 
 from aiohttp.client_exceptions import ServerDisconnectedError
 
@@ -179,7 +178,7 @@ class Bootstrap(ProtectBaseObject):
     sensors: dict[str, Sensor]
     doorlocks: dict[str, Doorlock]
     chimes: dict[str, Chime]
-    last_update_id: UUID
+    last_update_id: str
 
     # TODO:
     # schedules
@@ -546,7 +545,7 @@ class Bootstrap(ProtectBaseObject):
 
         action, data = self._get_frame_data(packet)
         if action["newUpdateId"] is not None:
-            self.last_update_id = UUID(action["newUpdateId"])
+            self.last_update_id = action["newUpdateId"]
 
         if action["modelKey"] not in ModelType.values():
             _LOGGER.debug("Unknown model type: %s", action["modelKey"])

--- a/src/uiprotect/data/websocket.py
+++ b/src/uiprotect/data/websocket.py
@@ -8,7 +8,6 @@ import struct
 import zlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-from uuid import UUID
 
 import orjson
 
@@ -40,7 +39,7 @@ class WSAction(str, enum.Enum):
 @dataclass
 class WSSubscriptionMessage:
     action: WSAction
-    new_update_id: UUID
+    new_update_id: str
     changed_data: dict[str, Any]
     new_obj: ProtectModelWithId | None = None
     old_obj: ProtectModelWithId | None = None


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The last_update_id is currently a UUID but since we never need to transform it,[ and only send it back after converting it back to a string](https://github.com/uilibs/uiprotect/blob/f6ca464cafc25c6660883cfb538e04e9b4730ab8/src/uiprotect/api.py#L227), we can avoid parsing it.

process_ws_packet spends 22% of its runtime converting the string to a UUID

It also means that there is no risk of accidentally reformatting (upper, lower, etc) the data when returning it to the api. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal data types for better consistency and performance. This change does not impact user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->