### PR TITLE
refactor: remove useless .keys() calls

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -824,7 +824,7 @@ class ProtectApiClient(BaseApiClient):
                 msg.action,
                 msg.new_obj.model,
                 msg.new_obj.id,
-                list(msg.changed_data.keys()),
+                list(msg.changed_data),
             )
         elif msg.old_obj is not None:
             _LOGGER.debug(

--- a/src/uiprotect/cli/backup.py
+++ b/src/uiprotect/cli/backup.py
@@ -814,7 +814,7 @@ def _add_metadata(path: Path, creation: datetime, title: str) -> bool:
                 in_to_out[stream] = output_file.add_stream(template=stream)  # type: ignore[index]
                 in_to_out[stream].metadata["creation_time"] = creation.isoformat()  # type: ignore[index]
 
-            for packet in input_file.demux(list(in_to_out.keys())):
+            for packet in input_file.demux(list(in_to_out)):
                 if packet.dts is None:
                     continue
 

--- a/src/uiprotect/data/base.py
+++ b/src/uiprotect/data/base.py
@@ -338,7 +338,7 @@ class ProtectBaseObject(BaseModel):
             data[remaps[from_key]] = data.pop(from_key)
 
         # convert to snake_case and remove extra fields
-        for key in list(data.keys()):
+        for key in list(data):
             new_key = to_snake_case(key)
             data[new_key] = data.pop(key)
             key = new_key
@@ -765,7 +765,7 @@ class ProtectModelWithId(ProtectModel):
         if updated == {}:
             return
 
-        read_only_keys = read_only_fields.intersection(updated.keys())
+        read_only_keys = read_only_fields.intersection(updated)
         if len(read_only_keys) > 0:
             self.revert_changes(data_before_changes)
             raise BadRequest(

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -1034,7 +1034,7 @@ class Camera(ProtectMotionDeviceModel):
     @classmethod
     def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
         # LCD messages comes back as empty dict {}
-        if "lcdMessage" in data and len(data["lcdMessage"].keys()) == 0:
+        if "lcdMessage" in data and len(data["lcdMessage"]) == 0:
             del data["lcdMessage"]
         if "chimeDuration" in data and not isinstance(data["chimeDuration"], timedelta):
             data["chimeDuration"] = timedelta(milliseconds=data["chimeDuration"])

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -152,7 +152,7 @@ class EventThumbnailAttributes(ProtectBaseObject):
     ) -> dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
 
-        for key in DELETE_KEYS_THUMB.intersection(data.keys()):
+        for key in DELETE_KEYS_THUMB.intersection(data):
             if data[key] is None:
                 del data[key]
 
@@ -240,7 +240,7 @@ class EventMetadata(ProtectBaseObject):
 
     @classmethod
     def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        for key in cls._collapse_keys.intersection(data.keys()):
+        for key in cls._collapse_keys.intersection(data):
             if isinstance(data[key], dict):
                 data[key] = data[key]["text"]
 
@@ -258,7 +258,7 @@ class EventMetadata(ProtectBaseObject):
             if value is None:
                 del data[key]
 
-        for key in self._collapse_keys.intersection(data.keys()):
+        for key in self._collapse_keys.intersection(data):
             # AI Theta/Hotplug exception
             if key != "type" or data[key] not in {"audio", "video", "extender"}:
                 data[key] = {"text": data[key]}
@@ -308,7 +308,7 @@ class Event(ProtectModelWithId):
 
     @classmethod
     def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        for key in {"start", "end", "timestamp", "deletedAt"}.intersection(data.keys()):
+        for key in {"start", "end", "timestamp", "deletedAt"}.intersection(data):
             data[key] = process_datetime(data, key)
 
         return super().unifi_dict_to_dict(data)
@@ -320,7 +320,7 @@ class Event(ProtectModelWithId):
     ) -> dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
 
-        for key in DELETE_KEYS_EVENT.intersection(data.keys()):
+        for key in DELETE_KEYS_EVENT.intersection(data):
             if data[key] is None:
                 del data[key]
 

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -50,7 +50,7 @@ class FixSizeOrderedDict(dict[KT, VT]):
         """Set an update up to the max size."""
         dict.__setitem__(self, key, value)
         if self._max_size > 0 and len(self) > 0 and len(self) > self._max_size:
-            del self[next(iter(self.keys()))]
+            del self[next(iter(self))]
 
 
 class ValuesEnumMixin:

--- a/src/uiprotect/utils.py
+++ b/src/uiprotect/utils.py
@@ -278,7 +278,7 @@ def serialize_unifi_obj(value: Any, levels: int = -1) -> Any:
 
 def serialize_dict(data: dict[str, Any], levels: int = -1) -> dict[str, Any]:
     """Serializes UFP data dict"""
-    for key in list(data.keys()):
+    for key in list(data):
         set_key = key
         if set_key not in SNAKE_CASE_KEYS:
             set_key = to_camel_case(set_key)


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
refactor: remove useless .keys() calls

`keys()` is the default so its not needed in these places