### PR TITLE
feat: guard debug logging that reformats data in the arguments

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -23,3 +23,4 @@ exclude_lines =
     if TYPE_CHECKING:
     @overload
     except ImportError:
+    if _LOGGER.isEnabledFor(logging.DEBUG):

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -818,23 +818,26 @@ class ProtectApiClient(BaseApiClient):
         return self._bootstrap
 
     def emit_message(self, msg: WSSubscriptionMessage) -> None:
-        if msg.new_obj is not None:
-            _LOGGER.debug(
-                "emitting message: %s:%s:%s:%s",
-                msg.action,
-                msg.new_obj.model,
-                msg.new_obj.id,
-                list(msg.changed_data.keys()),
-            )
-        elif msg.old_obj is not None:
-            _LOGGER.debug(
-                "emitting message: %s:%s:%s",
-                msg.action,
-                msg.old_obj.model,
-                msg.old_obj.id,
-            )
-        else:
-            _LOGGER.debug("emitting message: %s", msg.action)
+        """Emit message to all subscriptions."""
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            if msg.new_obj is not None:
+                _LOGGER.debug(
+                    "emitting message: %s:%s:%s:%s",
+                    msg.action,
+                    msg.new_obj.model,
+                    msg.new_obj.id,
+                    list(msg.changed_data.keys()),
+                )
+            elif msg.old_obj is not None:
+                _LOGGER.debug(
+                    "emitting message: %s:%s:%s",
+                    msg.action,
+                    msg.old_obj.model,
+                    msg.old_obj.id,
+                )
+            else:
+                _LOGGER.debug("emitting message: %s", msg.action)
+
         for sub in self._ws_subscriptions:
             try:
                 sub(msg)


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
The reformatting runs even if debug logging is disabled
