### PR TITLE
feat: avoid linear searches to process websocket packets

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -1075,7 +1075,10 @@ class ProtectApiClient(BaseApiClient):
 
         for event_dict in response:
             # ignore unknown events
-            if "type" not in event_dict or event_dict["type"] not in EventType.values():
+            if (
+                "type" not in event_dict
+                or event_dict["type"] not in EventType.values_set()
+            ):
                 _LOGGER.debug("Unknown event type: %s", event_dict)
                 continue
 
@@ -1086,7 +1089,7 @@ class ProtectApiClient(BaseApiClient):
                 continue
 
             if (
-                event.type.value in EventType.device_events()
+                event.type.value in EventType.device_events_set()
                 and event.score >= self._minimum_score
             ):
                 events.append(event)

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -553,7 +553,7 @@ class Bootstrap(ProtectBaseObject):
         if action["newUpdateId"] is not None:
             self.last_update_id = action["newUpdateId"]
 
-        if action["modelKey"] not in ModelType.values():
+        if action["modelKey"] not in ModelType.values_set():
             _LOGGER.debug("Unknown model type: %s", action["modelKey"])
             self._create_stat(packet, [], True)
             return None
@@ -577,7 +577,7 @@ class Bootstrap(ProtectBaseObject):
                 if action["modelKey"] == ModelType.NVR.value:
                     return self._process_nvr_update(packet, data, ignore_stats)
                 if (
-                    action["modelKey"] in ModelType.bootstrap_models()
+                    action["modelKey"] in ModelType.bootstrap_models_set()
                     or action["modelKey"] == ModelType.EVENT.value
                 ):
                     return self._process_device_update(

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 from collections.abc import Callable, Coroutine
+from functools import cache
 from typing import Any, Literal, Optional, TypeVar, Union
 
 from packaging.version import Version as BaseVersion
@@ -58,10 +59,16 @@ class ValuesEnumMixin:
     _values_normalized: dict[str, str] | None = None
 
     @classmethod
+    @cache
     def values(cls) -> list[str]:
         if cls._values is None:
             cls._values = [e.value for e in cls]  # type: ignore[attr-defined]
         return cls._values
+
+    @classmethod
+    @cache
+    def values_set(cls) -> set[str]:
+        return set(cls.values())
 
     @classmethod
     def _missing_(cls, value: Any) -> Any | None:
@@ -103,6 +110,7 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
     UNKNOWN = "unknown"
 
     @staticmethod
+    @cache
     def bootstrap_models() -> tuple[str, ...]:
         # TODO:
         # legacyUFV
@@ -120,6 +128,11 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
             ModelType.DOORLOCK.value,
             ModelType.CHIME.value,
         )
+
+    @staticmethod
+    @cache
+    def bootstrap_models_set() -> set[str]:
+        return set(ModelType.bootstrap_models())
 
 
 @enum.unique
@@ -204,6 +217,7 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     RECORDING_OFF = "recordingOff"
 
     @staticmethod
+    @cache
     def device_events() -> list[str]:
         return [
             EventType.MOTION.value,
@@ -212,6 +226,12 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
         ]
 
     @staticmethod
+    @cache
+    def device_events_set() -> set[str]:
+        return set(EventType.device_events())
+
+    @staticmethod
+    @cache
     def motion_events() -> list[str]:
         return [EventType.MOTION.value, EventType.SMART_DETECT.value]
 


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Avoid linear searches to process websocket packets

The event type, device events, and models all returned objects that had to do a linear search. Add methods to return a cached set instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced event filtering based on score for more precise event management.

- **Performance Improvements**
  - Implemented caching for various methods to improve performance and reduce redundant computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->