### PR TITLE
fix: remove useless time check

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -495,15 +495,12 @@ class Bootstrap(ProtectBaseObject):
             data = obj.unifi_dict_to_dict(data)
             old_obj = obj.copy()
             obj = obj.update_from_dict(deepcopy(data))
-            now: datetime | None = None
 
             if isinstance(obj, Event):
                 self.process_event(obj)
             elif isinstance(obj, Camera):
                 if "last_ring" in data and obj.last_ring:
-                    if now is None:
-                        now = utc_now()
-                    is_recent = obj.last_ring + RECENT_EVENT_MAX >= now
+                    is_recent = obj.last_ring + RECENT_EVENT_MAX >= utc_now()
                     _LOGGER.debug("last_ring for %s (%s)", obj.id, is_recent)
                     if is_recent:
                         obj.set_ring_timeout()
@@ -512,9 +509,7 @@ class Bootstrap(ProtectBaseObject):
                 and "alarm_triggered_at" in data
                 and obj.alarm_triggered_at
             ):
-                if now is None:
-                    now = utc_now()
-                is_recent = obj.alarm_triggered_at + RECENT_EVENT_MAX >= now
+                is_recent = obj.alarm_triggered_at + RECENT_EVENT_MAX >= utc_now()
                 _LOGGER.debug("alarm_triggered_at for %s (%s)", obj.id, is_recent)
                 if is_recent:
                     obj.set_alarm_timeout()


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
#22 tried to reuse the time, but the code paths/objects are mutually exclusive so there is no reason to fetch it until we need it because its never reused.
