### PR TITLE
feat: cleanup processing of websocket packets

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -541,10 +541,11 @@ class Bootstrap(ProtectBaseObject):
     ) -> WSSubscriptionMessage | None:
         """Process a WS packet."""
         action, data = self._get_frame_data(packet)
-        if action["newUpdateId"] is not None:
-            self.last_update_id = action["newUpdateId"]
+        new_update_id: str = action["newUpdateId"]
+        if new_update_id is not None:
+            self.last_update_id = new_update_id
 
-        model_key = action["modelKey"]
+        model_key: str = action["modelKey"]
         if model_key not in ModelType.values_set():
             _LOGGER.debug("Unknown model type: %s", model_key)
             self._create_stat(packet, None, True)
@@ -554,7 +555,7 @@ class Bootstrap(ProtectBaseObject):
             self._create_stat(packet, None, True)
             return None
 
-        action_action = action["action"]
+        action_action: str = action["action"]
         if action_action == "remove":
             return self._process_remove_packet(packet, data)
 

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -41,7 +41,6 @@ from .types import EventType, FixSizeOrderedDict, ModelType
 from .user import Group, User
 from .websocket import (
     WSAction,
-    WSJSONPacketFrame,
     WSPacket,
     WSSubscriptionMessage,
 )
@@ -167,6 +166,10 @@ class WSStat:
 class ProtectDeviceRef(ProtectBaseObject):
     model: ModelType
     id: str
+
+
+_ModelType_NVR_value = ModelType.NVR.value
+_ModelType_Event_value = ModelType.EVENT.value
 
 
 class Bootstrap(ProtectBaseObject):
@@ -536,51 +539,39 @@ class Bootstrap(ProtectBaseObject):
         models: set[ModelType] | None = None,
         ignore_stats: bool = False,
     ) -> WSSubscriptionMessage | None:
-        if models is None:
-            models = set()
-
-        if not isinstance(packet.action_frame, WSJSONPacketFrame):
-            _LOGGER.debug(
-                "Unexpected action frame format: %s",
-                packet.action_frame.payload_format,
-            )
-
-        if not isinstance(packet.data_frame, WSJSONPacketFrame):
-            _LOGGER.debug(
-                "Unexpected data frame format: %s",
-                packet.data_frame.payload_format,
-            )
-
+        """Process a WS packet."""
         action, data = self._get_frame_data(packet)
         if action["newUpdateId"] is not None:
             self.last_update_id = action["newUpdateId"]
 
-        if action["modelKey"] not in ModelType.values_set():
-            _LOGGER.debug("Unknown model type: %s", action["modelKey"])
+        model_key = action["modelKey"]
+        if model_key not in ModelType.values_set():
+            _LOGGER.debug("Unknown model type: %s", model_key)
             self._create_stat(packet, None, True)
             return None
 
-        if len(models) > 0 and ModelType(action["modelKey"]) not in models:
+        if models and ModelType(model_key) not in models:
             self._create_stat(packet, None, True)
             return None
 
-        if action["action"] == "remove":
+        action_action = action["action"]
+        if action_action == "remove":
             return self._process_remove_packet(packet, data)
 
-        if data is None or len(data) == 0:
+        if not data:
             self._create_stat(packet, None, True)
             return None
 
         try:
-            if action["action"] == "add":
+            if action_action == "add":
                 return self._process_add_packet(packet, data)
-
-            if action["action"] == "update":
-                if action["modelKey"] == ModelType.NVR.value:
+            if action_action == "update":
+                if model_key == _ModelType_NVR_value:
                     return self._process_nvr_update(packet, data, ignore_stats)
+
                 if (
-                    action["modelKey"] in ModelType.bootstrap_models_set()
-                    or action["modelKey"] == ModelType.EVENT.value
+                    model_key in ModelType.bootstrap_models_set()
+                    or model_key == _ModelType_Event_value
                 ):
                     return self._process_device_update(
                         packet,
@@ -588,13 +579,12 @@ class Bootstrap(ProtectBaseObject):
                         data,
                         ignore_stats,
                     )
-                _LOGGER.debug(
-                    "Unexpected bootstrap model type deviceadoptedfor update: %s",
-                    action["modelKey"],
-                )
         except (ValidationError, ValueError) as err:
             self._handle_ws_error(action, err)
 
+        _LOGGER.debug(
+            "Unexpected bootstrap model type deviceadoptedfor update: %s", model_key
+        )
         self._create_stat(packet, None, True)
         return None
 

--- a/src/uiprotect/data/websocket.py
+++ b/src/uiprotect/data/websocket.py
@@ -7,7 +7,7 @@ import enum
 import struct
 import zlib
 from dataclasses import dataclass
-from functools import cached_property
+from functools import cache, cached_property
 from typing import TYPE_CHECKING, Any
 
 import orjson
@@ -63,6 +63,7 @@ class BaseWSPacketFrame:
         raise NotImplementedError
 
     @staticmethod
+    @cache
     def klass_from_format(format_raw: int) -> type[BaseWSPacketFrame]:
         payload_format = ProtectWSPayloadFormat(format_raw)
 

--- a/src/uiprotect/data/websocket.py
+++ b/src/uiprotect/data/websocket.py
@@ -7,6 +7,7 @@ import enum
 import struct
 import zlib
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 import orjson
@@ -174,13 +175,15 @@ class WSJSONPacketFrame(BaseWSPacketFrame):
 
 
 class WSPacket:
+    """Class to handle a unifi protect websocket packet."""
+
     _raw: bytes
     _raw_encoded: str | None = None
 
     _action_frame: BaseWSPacketFrame | None = None
     _data_frame: BaseWSPacketFrame | None = None
 
-    def __init__(self, data: bytes):
+    def __init__(self, data: bytes) -> None:
         self._raw = data
 
     def decode(self) -> None:
@@ -190,7 +193,7 @@ class WSPacket:
             self._action_frame.length,
         )
 
-    @property
+    @cached_property
     def action_frame(self) -> BaseWSPacketFrame:
         if self._action_frame is None:
             self.decode()
@@ -200,7 +203,7 @@ class WSPacket:
 
         return self._action_frame
 
-    @property
+    @cached_property
     def data_frame(self) -> BaseWSPacketFrame:
         if self._data_frame is None:
             self.decode()
@@ -220,6 +223,8 @@ class WSPacket:
         self._action_frame = None
         self._data_frame = None
         self._raw_encoded = None
+        self.__dict__.pop("data_frame", None)
+        self.__dict__.pop("action_frame", None)
 
     @property
     def raw_base64(self) -> str:


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
- remove unreachable code that checked type of data since invalid data already raises in the `WSPacket` class
- cache the result of the `WSPacket` properties
- avoid many dict lookups in the websocket data processing
- avoid creating enums in the websocket packet processing
- avoid useless set creation on every packet when models is not passed
- add some missing types
- cache `klass_from_format` since the inputs are almost all the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved performance by replacing some property decorators with cached property decorators.
  - Enhanced type safety with added return type hints for initialization methods.

- **Bug Fixes**
  - Enhanced handling of various action types and models to prevent unexpected behavior.
  - Added debug logging for better troubleshooting of unexpected model types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->