### PR TITLE
feat: cache bootstrap on the ProtectApiClient once it has been initialized

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -11,6 +11,7 @@ import sys
 import time
 from collections.abc import Callable
 from datetime import datetime, timedelta
+from functools import cached_property
 from http.cookies import Morsel, SimpleCookie
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
@@ -749,10 +750,10 @@ class ProtectApiClient(BaseApiClient):
     def is_ready(self) -> bool:
         return self._bootstrap is not None
 
-    @property
+    @cached_property
     def bootstrap(self) -> Bootstrap:
         if self._bootstrap is None:
-            raise BadRequest("Client not initalized, run `update` first")
+            raise BadRequest("Client not initialized, run `update` first")
 
         return self._bootstrap
 

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -794,6 +794,7 @@ class ProtectApiClient(BaseApiClient):
         if self._bootstrap is None or now - self._last_update > DEVICE_UPDATE_INTERVAL:
             bootstrap_updated = True
             self._bootstrap = await self.get_bootstrap()
+            self.__dict__.pop("bootstrap", None)
             self._last_update = now
             self._last_update_dt = now_dt
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -316,6 +316,14 @@ async def test_force_update(protect_client: ProtectApiClient):
     await protect_client.update(force=True)
 
     assert protect_client.bootstrap
+    original_bootstrap = protect_client.bootstrap
+    protect_client._bootstrap = None
+    with patch("uiprotect.api.ProtectApiClient.get_bootstrap", AsyncMock()) as mock:
+        await protect_client.update(force=False)
+        assert mock.called
+
+    assert protect_client.bootstrap
+    assert original_bootstrap != protect_client.bootstrap
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
cache bootstrap on the ProtectApiClient once it has been initialized.  Reset the cache if its changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced performance by caching the `bootstrap` method.
  - Improved error message clarity for uninitialized client scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->