### PR TITLE
fix: missing url param in websocket disconnected error log message

### DIFF
--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -104,7 +104,7 @@ class Websocket:
                     break
                 self._reset_timeout()
         except ClientError:
-            _LOGGER.exception("Websocket disconnect error: %s")
+            _LOGGER.exception("Websocket disconnect error: %s", self.url)
         finally:
             _LOGGER.debug("Websocket disconnected")
             self._increase_failure()


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
The Websocket disconnect error logger message was missing the variable
