### PR TITLE
fix: new cookie flag preventing auth cookie from being stored

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -65,6 +65,13 @@ from .utils import (
 )
 from .websocket import Websocket
 
+if sys.version_info[:2] < (3, 13):
+    from http import cookies
+
+    # See: https://github.com/python/cpython/issues/112713
+    cookies.Morsel._reserved["partitioned"] = "partitioned"  # type: ignore[attr-defined]
+    cookies.Morsel._flags.add("partitioned")  # type: ignore[attr-defined]
+
 TOKEN_COOKIE_MAX_EXP_SECONDS = 60
 
 NEVER_RAN = -1000


### PR DESCRIPTION
As of UniFi Protect 4.0.5, they have started sending the cookie flag "partitioned". Python currently does not know about this (planned to be fixed in 3.13 https://github.com/python/cpython/issues/112713). This causes the cookie to be considered invalid, and thus the auth cookie is never saved. Since unifi protect rate limits authentication attempts this leads to 501 errors after a few requests are made.

This commit adds `partitioned` to the list of cookie flags the standard library accepts as valid. Thus allowing the cookie to be correctly parsed and saved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved compatibility for older Python versions (prior to 3.13) in handling cookies.
  - Introduced new constants for better token management: `TOKEN_COOKIE_MAX_EXP_SECONDS` and `NEVER_RAN`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->