### PR TITLE
feat: remove _get_frame_data helper

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -349,14 +349,6 @@ class Bootstrap(ProtectBaseObject):
                 ),
             )
 
-    def _get_frame_data(
-        self,
-        packet: WSPacket,
-    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
-        if self.capture_ws_stats:
-            return deepcopy(packet.action_frame.data), deepcopy(packet.data_frame.data)
-        return packet.action_frame.data, packet.data_frame.data
-
     def _process_add_packet(
         self,
         packet: WSPacket,
@@ -530,7 +522,12 @@ class Bootstrap(ProtectBaseObject):
         ignore_stats: bool = False,
     ) -> WSSubscriptionMessage | None:
         """Process a WS packet."""
-        action, data = self._get_frame_data(packet)
+        action = packet.action_frame.data
+        data = packet.data_frame.data
+        if self.capture_ws_stats:
+            action = deepcopy(action)
+            data = deepcopy(data)
+
         new_update_id: str = action["newUpdateId"]
         if new_update_id is not None:
             self.last_update_id = new_update_id


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
_get_frame_data is only now ever called in one place, remove it since it only serves to make it harder to understand what is going on in process_ws_packet

Long term we should refactor the `Bootstrap` class to be `BootstrapWithStats` so we can avoid all the complexity in the base class as stats are only used for tests
