### PR TITLE
feat: avoid fetching and iterating convert keys when empty

### DIFF
--- a/src/uiprotect/data/base.py
+++ b/src/uiprotect/data/base.py
@@ -141,21 +141,27 @@ class ProtectBaseObject(BaseModel):
         api: ProtectApiClient | None = values.pop("api", None)
         values_set = set(values)
 
-        if unifi_objs := cls._get_protect_objs():
-            for key in cls._get_protect_objs_set().intersection(values_set):
+        if (unifi_objs := cls._get_protect_objs()) and (
+            intersections := cls._get_protect_objs_set().intersection(values_set)
+        ):
+            for key in intersections:
                 if isinstance(values[key], dict):
                     values[key] = unifi_objs[key].construct(**values[key])
 
-        if unifi_lists := cls._get_protect_lists():
-            for key in cls._get_protect_lists_set().intersection(values_set):
+        if (unifi_lists := cls._get_protect_lists()) and (
+            intersections := cls._get_protect_lists_set().intersection(values_set)
+        ):
+            for key in intersections:
                 if isinstance(values[key], list):
                     values[key] = [
                         unifi_lists[key].construct(**v) if isinstance(v, dict) else v
                         for v in values[key]
                     ]
 
-        if unifi_dicts := cls._get_protect_dicts():
-            for key in cls._get_protect_dicts_set().intersection(values_set):
+        if (unifi_dicts := cls._get_protect_dicts()) and (
+            intersections := cls._get_protect_dicts_set().intersection(values_set)
+        ):
+            for key in intersections:
                 if isinstance(values[key], dict):
                     values[key] = {
                         k: unifi_dicts[key].construct(**v) if isinstance(v, dict) else v
@@ -336,8 +342,10 @@ class ProtectBaseObject(BaseModel):
         )
 
         # remap keys that will not be converted correctly by snake_case convert
-        if remaps := cls._get_unifi_remaps():
-            for from_key in cls._get_unifi_remaps_set().intersection(data):
+        if (remaps := cls._get_unifi_remaps()) and (
+            intersections := cls._get_unifi_remaps_set().intersection(data)
+        ):
+            for from_key in intersections:
                 data[remaps[from_key]] = data.pop(from_key)
 
         # convert to snake_case and remove extra fields
@@ -358,12 +366,16 @@ class ProtectBaseObject(BaseModel):
         # clean child UFP objs
         data_set = set(data)
 
-        if unifi_objs := cls._get_protect_objs():
-            for key in cls._get_protect_objs_set().intersection(data_set):
+        if (unifi_objs := cls._get_protect_objs()) and (
+            intersections := cls._get_protect_objs_set().intersection(data_set)
+        ):
+            for key in intersections:
                 data[key] = cls._clean_protect_obj(data[key], unifi_objs[key], api)
 
-        if unifi_lists := cls._get_protect_lists():
-            for key in cls._get_protect_lists_set().intersection(data_set):
+        if (unifi_lists := cls._get_protect_lists()) and (
+            intersections := cls._get_protect_lists_set().intersection(data_set)
+        ):
+            for key in intersections:
                 if isinstance(data[key], list):
                     data[key] = cls._clean_protect_obj_list(
                         data[key],
@@ -371,8 +383,10 @@ class ProtectBaseObject(BaseModel):
                         api,
                     )
 
-        if unifi_dicts := cls._get_protect_dicts():
-            for key in cls._get_protect_dicts_set().intersection(data_set):
+        if (unifi_dicts := cls._get_protect_dicts()) and (
+            intersections := cls._get_protect_dicts_set().intersection(data_set)
+        ):
+            for key in intersections:
                 if isinstance(data[key], dict):
                     data[key] = cls._clean_protect_obj_dict(
                         data[key],

--- a/src/uiprotect/data/base.py
+++ b/src/uiprotect/data/base.py
@@ -520,24 +520,34 @@ class ProtectBaseObject(BaseModel):
         data["api"] = api
         data_set = set(data)
 
-        for key in self._get_protect_objs_set().intersection(data_set):
-            unifi_obj: Any | None = getattr(self, key)
-            if unifi_obj is not None and isinstance(unifi_obj, dict):
-                unifi_obj["api"] = api
+        if (unifi_objs_sets := self._get_protect_objs_set()) and (
+            intersections := unifi_objs_sets.intersection(data_set)
+        ):
+            for key in intersections:
+                unifi_obj: Any | None = getattr(self, key)
+                if unifi_obj is not None and isinstance(unifi_obj, dict):
+                    unifi_obj["api"] = api
 
-        for key in self._get_protect_lists_set().intersection(data_set):
-            new_items = []
-            for item in data[key]:
-                if isinstance(item, dict):
-                    item["api"] = api
-                new_items.append(item)
-            data[key] = new_items
+        if (unifi_lists_sets := self._get_protect_lists_set()) and (
+            intersections := unifi_lists_sets.intersection(data_set)
+        ):
+            for key in intersections:
+                new_items = []
+                for item in data[key]:
+                    if isinstance(item, dict):
+                        item["api"] = api
+                    new_items.append(item)
+                data[key] = new_items
 
-        for key in self._get_protect_dicts_set().intersection(data_set):
-            for item_key, item in data[key].items():
-                if isinstance(item, dict):
-                    item["api"] = api
-                data[key][item_key] = item
+        if (unifi_dicts_sets := self._get_protect_dicts_set()) and (
+            intersections := unifi_dicts_sets.intersection(data_set)
+        ):
+            for key in intersections:
+                inner_dict: dict[str, Any] = data[key]
+                for item_key, item in inner_dict.items():
+                    if isinstance(item, dict):
+                        item["api"] = api
+                    inner_dict[item_key] = item
 
         return data
 


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The `construct` and `unifi_dict_to_dict` methods would fetch empty sets, call `intersection` on them, and than needlessly iterate them when the data to convert for the type was empty which lead to a lot of extra work that can be skipped.

This is ~30% reduction in set fetches + intersection calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the readability and maintainability of data protection and cleaning processes by simplifying logic and using more efficient assignment expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->