### PR TITLE
fix: blocking i/o in the event loop

### DIFF
--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -1198,16 +1198,15 @@ class NVR(ProtectDeviceModel):
 
     async def _read_cache_file(self, file_path: Path) -> set[Version] | None:
         versions: set[Version] | None = None
-
-        if file_path.is_file():
-            try:
-                _LOGGER.debug("Reading release cache file: %s", file_path)
-                async with aiofiles.open(file_path, "rb") as cache_file:
-                    versions = {
-                        Version(v) for v in orjson.loads(await cache_file.read())
-                    }
-            except Exception:
-                _LOGGER.warning("Failed to parse cache file: %s", file_path)
+        try:
+            _LOGGER.debug("Reading release cache file: %s", file_path)
+            async with aiofiles.open(file_path, "rb") as cache_file:
+                versions = {Version(v) for v in orjson.loads(await cache_file.read())}
+        except FileNotFoundError:
+            # ignore missing file
+            pass
+        except Exception:
+            _LOGGER.warning("Failed to parse cache file: %s", file_path)
 
         return versions
 


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
There was a blocking stat call in _read_cache_file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of reboot functionality by refining exception handling for missing cache files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->