### PR TITLE
feat: cleanup duplicate object lookups in event processing

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -315,16 +315,11 @@ class Bootstrap(ProtectBaseObject):
 
     def process_event(self, event: Event) -> None:
         event_type = event.type
-        if event_type in CAMERA_EVENT_ATTR_MAP and (camera := event.camera) is not None:
+        if event_type in CAMERA_EVENT_ATTR_MAP and (camera := event.camera):
             _process_camera_event(event, camera)
-        elif (
-            event_type is EventType.MOTION_LIGHT and (light := event.light) is not None
-        ):
+        elif event_type is EventType.MOTION_LIGHT and (light := event.light):
             _process_light_event(event, light)
-        elif (
-            event_type is EventType.MOTION_SENSOR
-            and (sensor := event.sensor) is not None
-        ):
+        elif event_type is EventType.MOTION_SENSOR and (sensor := event.sensor):
             _process_sensor_event(event, sensor)
 
         self.events[event.id] = event

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -80,12 +80,9 @@ CAMERA_EVENT_ATTR_MAP: dict[EventType, tuple[str, str]] = {
 }
 
 
-def _process_light_event(event: Event) -> None:
-    if event.light is None:
-        return
-
-    if _event_is_in_range(event, event.light.last_motion):
-        event.light.last_motion_event_id = event.id
+def _process_light_event(event: Event, light: Light) -> None:
+    if _event_is_in_range(event, light.last_motion):
+        light.last_motion_event_id = event.id
 
 
 def _event_is_in_range(event: Event, dt: datetime | None) -> bool:
@@ -95,22 +92,20 @@ def _event_is_in_range(event: Event, dt: datetime | None) -> bool:
     )
 
 
-def _process_sensor_event(event: Event) -> None:
-    if event.sensor is None:
-        return
+def _process_sensor_event(event: Event, sensor: Sensor) -> None:
     if event.type is EventType.MOTION_SENSOR:
-        if _event_is_in_range(event, event.sensor.motion_detected_at):
-            event.sensor.last_motion_event_id = event.id
+        if _event_is_in_range(event, sensor.motion_detected_at):
+            sensor.last_motion_event_id = event.id
     elif event.type in {EventType.SENSOR_CLOSED, EventType.SENSOR_OPENED}:
-        if _event_is_in_range(event, event.sensor.open_status_changed_at):
-            event.sensor.last_contact_event_id = event.id
+        if _event_is_in_range(event, sensor.open_status_changed_at):
+            sensor.last_contact_event_id = event.id
     elif event.type is EventType.SENSOR_EXTREME_VALUE:
-        if _event_is_in_range(event, event.sensor.extreme_value_detected_at):
-            event.sensor.extreme_value_detected_at = event.end
-            event.sensor.last_value_event_id = event.id
+        if _event_is_in_range(event, sensor.extreme_value_detected_at):
+            sensor.extreme_value_detected_at = event.end
+            sensor.last_value_event_id = event.id
     elif event.type is EventType.SENSOR_ALARM:
-        if _event_is_in_range(event, event.sensor.alarm_triggered_at):
-            event.sensor.last_value_event_id = event.id
+        if _event_is_in_range(event, sensor.alarm_triggered_at):
+            sensor.last_value_event_id = event.id
 
 
 _CAMERA_SMART_AND_LINE_EVENTS = {
@@ -120,10 +115,7 @@ _CAMERA_SMART_AND_LINE_EVENTS = {
 _CAMERA_SMART_AUDIO_EVENT = EventType.SMART_AUDIO_DETECT
 
 
-def _process_camera_event(event: Event) -> None:
-    if (camera := event.camera) is None:
-        return
-
+def _process_camera_event(event: Event, camera: Camera) -> None:
     event_type = event.type
     dt_attr, event_attr = CAMERA_EVENT_ATTR_MAP[event_type]
     dt: datetime | None = getattr(camera, dt_attr)
@@ -322,12 +314,18 @@ class Bootstrap(ProtectBaseObject):
         return cast(ProtectAdoptableDeviceModel, devices.get(ref.id))
 
     def process_event(self, event: Event) -> None:
-        if event.type in CAMERA_EVENT_ATTR_MAP and event.camera is not None:
-            _process_camera_event(event)
-        elif event.type == EventType.MOTION_LIGHT and event.light is not None:
-            _process_light_event(event)
-        elif event.type == EventType.MOTION_SENSOR and event.sensor is not None:
-            _process_sensor_event(event)
+        event_type = event.type
+        if event_type in CAMERA_EVENT_ATTR_MAP and (camera := event.camera) is not None:
+            _process_camera_event(event, camera)
+        elif (
+            event_type is EventType.MOTION_LIGHT and (light := event.light) is not None
+        ):
+            _process_light_event(event, light)
+        elif (
+            event_type is EventType.MOTION_SENSOR
+            and (sensor := event.sensor) is not None
+        ):
+            _process_sensor_event(event, sensor)
 
         self.events[event.id] = event
 


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Instead of fetching camera/lights/sensors twice, pass them to the processor and avoid the call if its unset
