### PR TITLE
feat: only process incoming websocket packet model type once

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -1146,7 +1146,7 @@ class ProtectApiClient(BaseApiClient):
 
     async def get_devices_raw(self, model_type: ModelType) -> list[dict[str, Any]]:
         """Gets a raw device list given a model_type"""
-        return await self.api_request_list(f"{model_type.value}s")
+        return await self.api_request_list(model_type.devices_key())
 
     async def get_devices(
         self,
@@ -1703,7 +1703,7 @@ class ProtectApiClient(BaseApiClient):
 
     async def adopt_device(self, model_type: ModelType, device_id: str) -> None:
         """Adopts a device"""
-        key = f"{model_type.value}s"
+        key = model_type.devices_key()
         data = await self.api_request_obj(
             "devices/adopt",
             method="post",

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -1146,7 +1146,7 @@ class ProtectApiClient(BaseApiClient):
 
     async def get_devices_raw(self, model_type: ModelType) -> list[dict[str, Any]]:
         """Gets a raw device list given a model_type"""
-        return await self.api_request_list(model_type.devices_key())
+        return await self.api_request_list(model_type.devices_key)
 
     async def get_devices(
         self,
@@ -1703,7 +1703,7 @@ class ProtectApiClient(BaseApiClient):
 
     async def adopt_device(self, model_type: ModelType, device_id: str) -> None:
         """Adopts a device"""
-        key = model_type.devices_key()
+        key = model_type.devices_key
         data = await self.api_request_obj(
             "devices/adopt",
             method="post",

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -348,7 +348,7 @@ class Bootstrap(ProtectBaseObject):
         packet: WSPacket,
         data: dict[str, Any],
     ) -> WSSubscriptionMessage | None:
-        obj = create_from_unifi_dict(data, api=self._api)
+        obj = create_from_unifi_dict(data, api=self._api, model_type=model_type)
         if model_type is ModelType.EVENT:
             if TYPE_CHECKING:
                 assert isinstance(obj, Event)

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -198,7 +198,7 @@ class Bootstrap(ProtectBaseObject):
         data["macLookup"] = {}
         data["idLookup"] = {}
         for model_type in ModelType.bootstrap_models_types_set():
-            key = model_type.devices_key()
+            key = model_type.devices_key
             items: dict[str, ProtectModel] = {}
             for item in data[key]:
                 if (
@@ -235,7 +235,7 @@ class Bootstrap(ProtectBaseObject):
             del data["idLookup"]
 
         for model_type in ModelType.bootstrap_models_types_set():
-            attr = model_type.devices_key()
+            attr = model_type.devices_key
             if attr in data and isinstance(data[attr], dict):
                 data[attr] = list(data[attr].values())
 
@@ -302,7 +302,7 @@ class Bootstrap(ProtectBaseObject):
         if ref is None:
             return None
 
-        devices: dict[str, ProtectModelWithId] = getattr(self, ref.model.devices_key())
+        devices: dict[str, ProtectModelWithId] = getattr(self, ref.model.devices_key)
         return cast(ProtectAdoptableDeviceModel, devices.get(ref.id))
 
     def get_device_from_id(self, device_id: str) -> ProtectAdoptableDeviceModel | None:
@@ -310,7 +310,7 @@ class Bootstrap(ProtectBaseObject):
         ref = self.id_lookup.get(device_id)
         if ref is None:
             return None
-        devices: dict[str, ProtectModelWithId] = getattr(self, ref.model.devices_key())
+        devices: dict[str, ProtectModelWithId] = getattr(self, ref.model.devices_key)
         return cast(ProtectAdoptableDeviceModel, devices.get(ref.id))
 
     def process_event(self, event: Event) -> None:
@@ -361,7 +361,7 @@ class Bootstrap(ProtectBaseObject):
             if TYPE_CHECKING:
                 assert isinstance(obj, ProtectAdoptableDeviceModel)
                 assert isinstance(obj.model, ModelType)
-            key = obj.model.devices_key()
+            key = obj.model.devices_key
             if not self._api.ignore_unadopted or (
                 obj.is_adopted and not obj.is_adopted_by_other
             ):
@@ -388,7 +388,7 @@ class Bootstrap(ProtectBaseObject):
         self, model_type: ModelType, packet: WSPacket
     ) -> WSSubscriptionMessage | None:
         devices: dict[str, ProtectDeviceModel] | None = getattr(
-            self, model_type.devices_key(), None
+            self, model_type.devices_key, None
         )
 
         if devices is None:
@@ -469,7 +469,7 @@ class Bootstrap(ProtectBaseObject):
             self._create_stat(packet, None, True)
             return None
 
-        devices: dict[str, ProtectModelWithId] = getattr(self, model_type.devices_key())
+        devices: dict[str, ProtectModelWithId] = getattr(self, model_type.devices_key)
         action_id: str = action["id"]
         if action_id not in devices:
             # ignore updates to events that phase out
@@ -611,7 +611,7 @@ class Bootstrap(ProtectBaseObject):
             self.nvr = device
         else:
             devices: dict[str, ProtectModelWithId] = getattr(
-                self, model_type.devices_key()
+                self, model_type.devices_key
             )
             devices[device.id] = device
         _LOGGER.debug("Successfully refresh model: %s %s", model_type, device_id)

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -197,8 +197,8 @@ class Bootstrap(ProtectBaseObject):
         )
         data["macLookup"] = {}
         data["idLookup"] = {}
-        for model_type in ModelType.bootstrap_models():
-            key = f"{model_type}s"
+        for model_type in ModelType.bootstrap_models_types_set():
+            key = model_type.devices_key()
             items: dict[str, ProtectModel] = {}
             for item in data[key]:
                 if (
@@ -234,8 +234,8 @@ class Bootstrap(ProtectBaseObject):
         if "idLookup" in data:
             del data["idLookup"]
 
-        for model_type in ModelType.bootstrap_models():
-            attr = f"{model_type}s"
+        for model_type in ModelType.bootstrap_models_types_set():
+            attr = model_type.devices_key()
             if attr in data and isinstance(data[attr], dict):
                 data[attr] = list(data[attr].values())
 
@@ -302,7 +302,7 @@ class Bootstrap(ProtectBaseObject):
         if ref is None:
             return None
 
-        devices: dict[str, ProtectModelWithId] = getattr(self, f"{ref.model.value}s")
+        devices: dict[str, ProtectModelWithId] = getattr(self, ref.model.devices_key())
         return cast(ProtectAdoptableDeviceModel, devices.get(ref.id))
 
     def get_device_from_id(self, device_id: str) -> ProtectAdoptableDeviceModel | None:
@@ -310,7 +310,7 @@ class Bootstrap(ProtectBaseObject):
         ref = self.id_lookup.get(device_id)
         if ref is None:
             return None
-        devices: dict[str, ProtectModelWithId] = getattr(self, f"{ref.model.value}s")
+        devices: dict[str, ProtectModelWithId] = getattr(self, ref.model.devices_key())
         return cast(ProtectAdoptableDeviceModel, devices.get(ref.id))
 
     def process_event(self, event: Event) -> None:
@@ -361,7 +361,7 @@ class Bootstrap(ProtectBaseObject):
             if TYPE_CHECKING:
                 assert isinstance(obj, ProtectAdoptableDeviceModel)
                 assert isinstance(obj.model, ModelType)
-            key = f"{obj.model.value}s"
+            key = obj.model.devices_key()
             if not self._api.ignore_unadopted or (
                 obj.is_adopted and not obj.is_adopted_by_other
             ):
@@ -387,8 +387,9 @@ class Bootstrap(ProtectBaseObject):
     def _process_remove_packet(
         self, model_type: ModelType, packet: WSPacket
     ) -> WSSubscriptionMessage | None:
-        model = model_type.value
-        devices: dict[str, ProtectDeviceModel] | None = getattr(self, f"{model}s", None)
+        devices: dict[str, ProtectDeviceModel] | None = getattr(
+            self, model_type.devices_key(), None
+        )
 
         if devices is None:
             return None
@@ -468,8 +469,7 @@ class Bootstrap(ProtectBaseObject):
             self._create_stat(packet, None, True)
             return None
 
-        key = f"{model_type.value}s"
-        devices: dict[str, ProtectModelWithId] = getattr(self, key)
+        devices: dict[str, ProtectModelWithId] = getattr(self, model_type.devices_key())
         action_id: str = action["id"]
         if action_id not in devices:
             # ignore updates to events that phase out
@@ -611,7 +611,7 @@ class Bootstrap(ProtectBaseObject):
             self.nvr = device
         else:
             devices: dict[str, ProtectModelWithId] = getattr(
-                self, f"{model_type.value}s"
+                self, model_type.devices_key()
             )
             devices[device.id] = device
         _LOGGER.debug("Successfully refresh model: %s %s", model_type, device_id)

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -536,7 +536,7 @@ class Bootstrap(ProtectBaseObject):
             self._create_stat(packet, None, True)
             return None
 
-        model_type = ModelType(model_key)
+        model_type = ModelType.from_string(model_key)
         if models and model_type not in models:
             self._create_stat(packet, None, True)
             return None
@@ -578,7 +578,7 @@ class Bootstrap(ProtectBaseObject):
             msg = f"Validation error processing event: {action['id']}. Ignoring event."
         else:
             try:
-                model_type = ModelType(action["modelKey"])
+                model_type = ModelType.from_string(action["modelKey"])
                 device_id: str = action["id"]
                 task = asyncio.create_task(self.refresh_device(model_type, device_id))
                 self._refresh_tasks.add(task)

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -454,7 +454,6 @@ class Bootstrap(ProtectBaseObject):
         data: dict[str, Any],
         ignore_stats: bool,
     ) -> WSSubscriptionMessage | None:
-        model_key = model_type.value
         remove_keys = (
             STATS_AND_IGNORE_DEVICE_KEYS if ignore_stats else IGNORE_DEVICE_KEYS
         )
@@ -462,14 +461,14 @@ class Bootstrap(ProtectBaseObject):
             del data[key]
         # `last_motion` from cameras update every 100 milliseconds when a motion event is active
         # this overrides the behavior to only update `last_motion` when a new event starts
-        if model_key == "camera" and "lastMotion" in data:
+        if model_type is ModelType.CAMERA and "lastMotion" in data:
             del data["lastMotion"]
         # nothing left to process
         if not data:
             self._create_stat(packet, None, True)
             return None
 
-        key = f"{model_key}s"
+        key = f"{model_type.value}s"
         devices: dict[str, ProtectModelWithId] = getattr(self, key)
         action_id: str = action["id"]
         if action_id not in devices:

--- a/src/uiprotect/data/convert.py
+++ b/src/uiprotect/data/convert.py
@@ -63,6 +63,7 @@ def create_from_unifi_dict(
     data: dict[str, Any],
     api: ProtectApiClient | None = None,
     klass: type[ProtectModel] | None = None,
+    model_type: ModelType | None = None,
 ) -> ProtectModel:
     """
     Helper method to read the `modelKey` from a UFP JSON dict and convert to currect Python class.
@@ -70,6 +71,9 @@ def create_from_unifi_dict(
     """
     if "modelKey" not in data:
         raise DataDecodeError("No modelKey")
+
+    if model_type is not None and klass is None:
+        klass = MODEL_TO_CLASS.get(model_type)
 
     if klass is None:
         klass = get_klass_from_dict(data)

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -111,28 +111,49 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
 
     @staticmethod
     @cache
-    def bootstrap_models() -> tuple[str, ...]:
+    def bootstrap_model_types() -> tuple[ModelType, ...]:
+        """Return the bootstrap models as a tuple."""
         # TODO:
         # legacyUFV
         # display
-
         return (
-            ModelType.CAMERA.value,
-            ModelType.USER.value,
-            ModelType.GROUP.value,
-            ModelType.LIVEVIEW.value,
-            ModelType.VIEWPORT.value,
-            ModelType.LIGHT.value,
-            ModelType.BRIDGE.value,
-            ModelType.SENSOR.value,
-            ModelType.DOORLOCK.value,
-            ModelType.CHIME.value,
+            ModelType.CAMERA,
+            ModelType.USER,
+            ModelType.GROUP,
+            ModelType.LIVEVIEW,
+            ModelType.VIEWPORT,
+            ModelType.LIGHT,
+            ModelType.BRIDGE,
+            ModelType.SENSOR,
+            ModelType.DOORLOCK,
+            ModelType.CHIME,
+        )
+
+    @staticmethod
+    @cache
+    def bootstrap_models() -> tuple[str, ...]:
+        """Return the bootstrap models strings as a tuple."""
+        return tuple(
+            model_type.value for model_type in ModelType.bootstrap_model_types()
         )
 
     @staticmethod
     @cache
     def bootstrap_models_set() -> set[str]:
+        """Return the set of bootstrap models strings as a set."""
         return set(ModelType.bootstrap_models())
+
+    @staticmethod
+    @cache
+    def bootstrap_models_types_set() -> set[ModelType]:
+        """Return the set of bootstrap models as a set."""
+        return set(ModelType.bootstrap_model_types())
+
+    @staticmethod
+    @cache
+    def bootstrap_models_types_and_event_set() -> set[ModelType]:
+        """Return the set of bootstrap models and the event model as a set."""
+        return ModelType.bootstrap_models_types_set() | {ModelType.EVENT}
 
 
 @enum.unique

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -109,11 +109,10 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
     RECORDING_SCHEDULE = "recordingSchedule"
     UNKNOWN = "unknown"
 
-    @classmethod
-    @cache
-    def devices_key(cls) -> str:
+    @cache  # - enums are singletons
+    def devices_key(self) -> str:
         """Return the devices key."""
-        return f"{cls.value}s"
+        return f"{self.value}s"
 
     @classmethod
     @cache

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -109,6 +109,11 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
     RECORDING_SCHEDULE = "recordingSchedule"
     UNKNOWN = "unknown"
 
+    @classmethod
+    @cache
+    def from_string(cls, value: str) -> ModelType:
+        return cls(value)
+
     @staticmethod
     @cache
     def bootstrap_model_types() -> tuple[ModelType, ...]:

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -111,6 +111,12 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
 
     @classmethod
     @cache
+    def devices_key(cls) -> str:
+        """Return the devices key."""
+        return f"{cls.value}s"
+
+    @classmethod
+    @cache
     def from_string(cls, value: str) -> ModelType:
         return cls(value)
 

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from collections.abc import Callable, Coroutine
-from functools import cache
+from functools import cache, cached_property
 from typing import Any, Literal, Optional, TypeVar, Union
 
 from packaging.version import Version as BaseVersion
@@ -109,7 +109,7 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
     RECORDING_SCHEDULE = "recordingSchedule"
     UNKNOWN = "unknown"
 
-    @cache  # - enums are singletons
+    @cached_property
     def devices_key(self) -> str:
         """Return the devices key."""
         return f"{self.value}s"

--- a/src/uiprotect/data/user.py
+++ b/src/uiprotect/data/user.py
@@ -54,7 +54,7 @@ class Permission(ProtectBaseObject):
         if self.obj_ids == {"self"} or self.obj_ids is None:
             return None
 
-        devices = getattr(self._api.bootstrap, f"{self.model.value}s")
+        devices = getattr(self._api.bootstrap, self.model.devices_key())
         return [devices[oid] for oid in self.obj_ids]
 
 

--- a/src/uiprotect/data/user.py
+++ b/src/uiprotect/data/user.py
@@ -54,7 +54,7 @@ class Permission(ProtectBaseObject):
         if self.obj_ids == {"self"} or self.obj_ids is None:
             return None
 
-        devices = getattr(self._api.bootstrap, self.model.devices_key())
+        devices = getattr(self._api.bootstrap, self.model.devices_key)
         return [devices[oid] for oid in self.obj_ids]
 
 


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
only process incoming websocket packet model type once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced device processing by introducing model-specific handling in various methods.

- **Improvements**
  - Streamlined device access by using model-specific keys instead of model values.
  - Improved flexibility with new methods for handling sets of model types and events.

- **Bug Fixes**
  - Ensured consistent model type behavior across different methods and modules.

- **Refactor**
  - Updated methods to use `ModelType` enums for more precise model handling and better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->