### PR TITLE
fix: ensure ping back messages are called back and empty updates excluded

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -541,9 +541,9 @@ class Bootstrap(ProtectBaseObject):
             self.last_update_id = new_update_id
 
         model_key: str = action["modelKey"]
-        model_type = ModelType.from_string_or_none(model_key)
+        model_type = ModelType.from_string(model_key)
 
-        if model_type is None:
+        if model_type is ModelType.UNKNOWN:
             _LOGGER.debug("Unknown model type: %s", model_key)
             self._create_stat(packet, None, True)
             return None

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -536,7 +536,7 @@ class Bootstrap(ProtectBaseObject):
             action = deepcopy(action)
             data = deepcopy(data)
 
-        new_update_id: str = action["newUpdateId"]
+        new_update_id: str | None = action["newUpdateId"]
         if new_update_id is not None:
             self.last_update_id = new_update_id
 

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -541,9 +541,7 @@ class Bootstrap(ProtectBaseObject):
             self.last_update_id = new_update_id
 
         model_key: str = action["modelKey"]
-        model_type = ModelType.from_string(model_key)
-
-        if model_type is ModelType.UNKNOWN:
+        if (model_type := ModelType.from_string(model_key)) is ModelType.UNKNOWN:
             _LOGGER.debug("Unknown model type: %s", model_key)
             self._create_stat(packet, None, True)
             return None

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -479,6 +479,12 @@ class Bootstrap(ProtectBaseObject):
 
         obj = devices[action_id]
         data = obj.unifi_dict_to_dict(data)
+
+        if not data:
+            # nothing left to process
+            self._create_stat(packet, None, True)
+            return None
+
         old_obj = obj.copy()
         obj = obj.update_from_dict(deepcopy(data))
 

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -126,14 +126,6 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
         return cls(value)
 
     @classmethod
-    @cache
-    def from_string_or_none(cls, value: str) -> ModelType | None:
-        try:
-            return cls.from_string(value)
-        except ValueError:
-            return None
-
-    @classmethod
     def _bootstrap_model_types(cls) -> tuple[ModelType, ...]:
         """Return the bootstrap models as a tuple."""
         # TODO:

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -126,6 +126,14 @@ class ModelType(str, UnknownValuesEnumMixin, enum.Enum):
         return cls(value)
 
     @classmethod
+    @cache
+    def from_string_or_none(cls, value: str) -> ModelType | None:
+        try:
+            return cls.from_string(value)
+        except ValueError:
+            return None
+
+    @classmethod
     def _bootstrap_model_types(cls) -> tuple[ModelType, ...]:
         """Return the bootstrap models as a tuple."""
         # TODO:

--- a/tests/data/test_types.py
+++ b/tests/data/test_types.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+
+from uiprotect.data.types import ModelType
+
+
+@pytest.mark.asyncio()
+async def test_model_type_from_string():
+    assert ModelType.from_string("camera") is ModelType.CAMERA
+    assert ModelType.from_string("invalid") is ModelType.UNKNOWN

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -412,6 +412,7 @@ async def test_ws_event_update(
 
 @pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
 @patch("uiprotect.data.devices.utc_now")
+@patch("uiprotect.data.base.EVENT_PING_INTERVAL_SECONDS", 0)
 @pytest.mark.asyncio()
 async def test_ws_emit_ring_callback(
     mock_now,
@@ -448,6 +449,18 @@ async def test_ws_emit_ring_callback(
     assert obj.is_ringing
     mock_now.return_value = utc_now() + EVENT_PING_INTERVAL
     assert not obj.is_ringing
+
+    # The event message should be emitted
+    assert protect_client.emit_message.call_count == 1
+
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    # An empty messages should be emitted
+    assert protect_client.emit_message.call_count == 2
+
+    message: WSSubscriptionMessage = protect_client.emit_message.call_args[0][0]
+    assert message.changed_data == {}
 
 
 @pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")


### PR DESCRIPTION


<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
There was a check for empty device updates ealier in the function but we did not check again after unifi_dict_to_dict so we did a lot of useless callbacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new functionality for handling empty dictionaries in WebSocket packet processing.

- **Bug Fixes**
  - Added conditional checks to prevent errors when handling empty data.

- **Tests**
  - Added tests for the `ModelType` enum's `from_string` method to verify correct string-to-enum conversions.
  - Updated WebSocket emission tests to include new conditions and assertions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->