### PR TITLE
feat: make websocket dataclasses sloted

### DIFF
--- a/src/uiprotect/data/websocket.py
+++ b/src/uiprotect/data/websocket.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 WS_HEADER_SIZE = 8
 
 
-@dataclass
+@dataclass(slots=True)
 class WSPacketFrameHeader:
     packet_type: int
     payload_format: int
@@ -37,7 +37,7 @@ class WSAction(str, enum.Enum):
     REMOVE = "remove"
 
 
-@dataclass
+@dataclass(slots=True)
 class WSSubscriptionMessage:
     action: WSAction
     new_update_id: str


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
This is now possible since the min python is 3.10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Optimization**
  - Improved memory efficiency and performance by enhancing the `WSPacketFrameHeader` and `WSSubscriptionMessage` classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->