### PR TITLE
fix: revert to using protected attrs for property cache

### DIFF
--- a/src/uiprotect/data/base.py
+++ b/src/uiprotect/data/base.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from functools import cache, cached_property
+from functools import cache
 from ipaddress import IPv4Address
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 from uuid import UUID
@@ -89,7 +89,6 @@ class ProtectBaseObject(BaseModel):
         arbitrary_types_allowed = True
         validate_assignment = True
         copy_on_model_validation = "shallow"
-        keep_untouched = (cached_property,)
 
     def __init__(self, api: ProtectApiClient | None = None, **data: Any) -> None:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -349,7 +349,7 @@ async def test_bootstrap_cached_property(protect_client: ProtectApiClient):
     assert bootstrap.has_doorbell is True
     bootstrap.cameras = {}
     assert bootstrap.has_doorbell is True
-    del bootstrap.__dict__["has_doorbell"]
+    bootstrap._has_doorbell = None
     assert bootstrap.has_doorbell is False
 
 


### PR DESCRIPTION

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
partially reverts #68 since HA tests are resetting the properties by adjusting the underscore values.
