### PR TITLE
feat: add repr for websocket packets

### DIFF
--- a/src/uiprotect/data/websocket.py
+++ b/src/uiprotect/data/websocket.py
@@ -56,6 +56,9 @@ class BaseWSPacketFrame:
     is_deflated: bool = False
     length: int = 0
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} header={self.header} data={self.data}>"
+
     def set_data_from_binary(self, data: bytes) -> None:
         self.data = data
         if self.header is not None and self.header.deflated:
@@ -187,6 +190,9 @@ class WSPacket:
 
     def __init__(self, data: bytes) -> None:
         self._raw = data
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} action_frame={self.action_frame} data_frame={self.data_frame}>"
 
     def decode(self) -> None:
         data = self._raw


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Improves the ability to debug by making websocket packets more human readable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved string representation for certain WebSocket packet classes to enhance debugging and logging.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->