### PR TITLE
fix: ensure camera and chime keys are not included in the base ignored set

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -67,7 +67,7 @@ STATS_KEYS = {
     "recordingSchedules",
 }
 
-IGNORE_DEVICE_KEYS = {"nvrMac", "guid", "lastMotion", "cameraIds"}
+IGNORE_DEVICE_KEYS = {"nvrMac", "guid"}
 STATS_AND_IGNORE_DEVICE_KEYS = STATS_KEYS | IGNORE_DEVICE_KEYS
 
 _IGNORE_KEYS_BY_MODEL_TYPE = {


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

refactoring error introduced in #85 that I forgot to remove when I was testing
