### PR TITLE
chore: remove ancient protect 1.2 workarounds

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -195,33 +195,6 @@ def test_early_bootstrap():
 
 @pytest.mark.asyncio()
 @pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
-async def test_bootstrap_fix_record_mode(bootstrap):
-    expected_updates = 1
-    orig_bootstrap = deepcopy(bootstrap)
-    bootstrap["cameras"][0]["recordingSettings"]["mode"] = "motion"
-    if len(bootstrap["cameras"]) > 1:
-        expected_updates = 2
-        bootstrap["cameras"][1]["recordingSettings"]["mode"] = "smartDetect"
-
-    client = ProtectApiClient(
-        "127.0.0.1",
-        0,
-        "username",
-        "password",
-        debug=True,
-        store_sessions=False,
-    )
-    client.api_request_obj = AsyncMock(side_effect=[bootstrap, orig_bootstrap])
-    client.update_device = AsyncMock()
-
-    await client.get_bootstrap()
-
-    assert client.api_request_obj.call_count == 2
-    assert client.update_device.call_count == expected_updates
-
-
-@pytest.mark.asyncio()
-@pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
 async def test_bootstrap_get_device_from_mac(bootstrap):
     orig_bootstrap = deepcopy(bootstrap)
     mac = bootstrap["cameras"][0]["mac"]


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
emove ancient protect 1.2 workarounds for long fixed protect bugs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issues with camera recording settings, ensuring more stable and reliable recording modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->