### PR TITLE
fix: ensure update_from_dict creates the object is it was previously None

### DIFF
--- a/src/uiprotect/data/base.py
+++ b/src/uiprotect/data/base.py
@@ -483,7 +483,7 @@ class ProtectBaseObject(BaseModel):
                 if (unifi_obj := getattr(cls, key)) is not None:
                     value = unifi_obj.update_from_dict(item)
                 else:
-                    value = None
+                    value = unifi_objs[key](**item, api=api)
             elif has_unifi_lists and key in unifi_lists and isinstance(item, list):
                 klass = unifi_lists[key]
                 value = [


### PR DESCRIPTION


### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

ensure update_from_dict creates the object is it was previously None

license plate metadata can change from none to and object via an update