### PR TITLE
feat!: rework websocket

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ source = src/uiprotect
 omit =
     site
     src/uiprotect/cli
+    src/uiprotect/test_util
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,8 +3,8 @@ source = src/uiprotect
 
 omit =
     site
-    src/uiprotect/cli
-    src/uiprotect/test_util
+    src/uiprotect/cli/*
+    src/uiprotect/test_util/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ source = src/uiprotect
 
 omit =
     site
+    src/uiprotect/cli
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -413,8 +413,13 @@ class BaseApiClient:
         )
 
         if data is not None:
-            json_data: list[Any] | dict[str, Any] = orjson.loads(data)
-            return json_data
+            json_data: list[Any] | dict[str, Any]
+            try:
+                json_data = orjson.loads(data)
+                return json_data
+            except orjson.JSONDecodeError as ex:
+                _LOGGER.error("Could not decode JSON from %s", url)
+                raise NvrError(f"Could not decode JSON from {url}") from ex
         return None
 
     async def api_request_obj(

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -261,6 +261,9 @@ class BaseApiClient:
             self.set_header("cookie", None)
             self.set_header("x-csrf-token", None)
             self._is_authenticated = False
+            # Force the next bootstrap update
+            # since the lastUpdateId is not valid anymore
+            self._last_update = NEVER_RAN
 
         await self.ensure_authenticated()
         return self.headers

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -261,9 +261,6 @@ class BaseApiClient:
             self.set_header("cookie", None)
             self.set_header("x-csrf-token", None)
             self._is_authenticated = False
-            # Force the next bootstrap update
-            # since the lastUpdateId is not valid anymore
-            self._last_update = NEVER_RAN
 
         await self.ensure_authenticated()
         return self.headers
@@ -274,12 +271,20 @@ class BaseApiClient:
             self._websocket = Websocket(
                 self.get_websocket_url,
                 self._auth_websocket,
+                self._update_bootstrap_soon,
                 self.get_session,
                 self._process_ws_message,
                 verify=self._verify_ssl,
                 timeout=self._ws_timeout,
             )
         return self._websocket
+
+    def _update_bootstrap_soon(self) -> None:
+        """Update bootstrap soon."""
+        _LOGGER.debug("Updating bootstrap soon")
+        # Force the next bootstrap update
+        # since the lastUpdateId is not valid anymore
+        self._last_update = NEVER_RAN
 
     async def close_session(self) -> None:
         """Closing and deletes client session"""

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -260,6 +260,7 @@ class BaseApiClient:
                 self._session.cookie_jar.clear()
             self.set_header("cookie", None)
             self.set_header("x-csrf-token", None)
+            self._is_authenticated = False
 
         await self.ensure_authenticated()
         return self.headers

--- a/src/uiprotect/cli/__init__.py
+++ b/src/uiprotect/cli/__init__.py
@@ -201,6 +201,7 @@ def shell(ctx: typer.Context) -> None:
 
     async def wait_forever() -> None:
         await protect.update()
+        protect.subscribe_websocket(lambda _: None)
         while True:
             await asyncio.sleep(10)
             await protect.update()
@@ -262,12 +263,16 @@ def profile_ws(
 
     async def callback() -> None:
         await protect.update()
+        unsub = protect.subscribe_websocket(lambda _: None)
         await profile_ws_job(
             protect,
             wait_time,
             output_path=output_path,
             ws_progress=_progress_bar,
         )
+        unsub()
+        await protect.async_disconnect_ws()
+        await protect.close_session()
 
     _setup_logger()
 

--- a/src/uiprotect/test_util/__init__.py
+++ b/src/uiprotect/test_util/__init__.py
@@ -105,7 +105,7 @@ class SampleDataGenerator:
         self.output_folder.mkdir(parents=True, exist_ok=True)
         websocket = self.client._get_websocket()
         websocket.start()
-        websocket.subscribe(self._handle_ws_message)
+        websocket._subscription = self._handle_ws_message
 
         self.log("Updating devices...")
         await self.client.update()

--- a/src/uiprotect/test_util/__init__.py
+++ b/src/uiprotect/test_util/__init__.py
@@ -105,6 +105,7 @@ class SampleDataGenerator:
         self.output_folder.mkdir(parents=True, exist_ok=True)
         websocket = self.client._get_websocket()
         websocket.start()
+        self.log("Websocket started...")
         websocket._subscription = self._handle_ws_message
 
         self.log("Updating devices...")
@@ -132,8 +133,10 @@ class SampleDataGenerator:
             "chime": len(bootstrap["chimes"]),
         }
 
+        self.log("Generating event data...")
         motion_event, smart_detection = await self.generate_event_data()
         await self.generate_device_data(motion_event, smart_detection)
+        self.log("Recording websocket events...")
         await self.record_ws_events()
 
         if close_session:

--- a/src/uiprotect/test_util/__init__.py
+++ b/src/uiprotect/test_util/__init__.py
@@ -103,7 +103,8 @@ class SampleDataGenerator:
     async def async_generate(self, close_session: bool = True) -> None:
         self.log(f"Output folder: {self.output_folder}")
         self.output_folder.mkdir(parents=True, exist_ok=True)
-        websocket = await self.client.get_websocket()
+        websocket = self.client._get_websocket()
+        websocket.start()
         websocket.subscribe(self._handle_ws_message)
 
         self.log("Updating devices...")

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -123,6 +123,7 @@ class Websocket:
                 self._headers = await self._auth(True)
             else:
                 _LOGGER.log(level, "Websocket handshake error: %s", url, exc_info=True)
+            raise
         except ClientError:
             level = logging.ERROR if self._last_ws_connect_ok else logging.DEBUG
             self._last_ws_connect_ok = False

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -102,6 +102,7 @@ class Websocket:
         _LOGGER.debug("Connecting WS to %s", url)
         self._headers = await self._auth(False)
         ssl = None if self.verify else False
+        msg: WSMessage | None = None
         # catch any and all errors for Websocket so we can clean up correctly
         try:
             session = await self._get_session()
@@ -130,7 +131,7 @@ class Websocket:
             _LOGGER.log(level, "Websocket disconnect error: %s", url, exc_info=True)
             raise
         finally:
-            _LOGGER.debug("Websocket disconnected")
+            _LOGGER.debug("Websocket disconnected: last message: %s", msg)
             if self._ws_connection is not None and not self._ws_connection.closed:
                 await self._ws_connection.close()
             self._ws_connection = None

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -66,7 +66,7 @@ class Websocket:
             _LOGGER.exception("Error from Websocket: %s", msg.data)
             return False
         elif msg.type in _CLOSE_MESSAGE_TYPES:
-            _LOGGER.debug("Websocket closed")
+            _LOGGER.debug("Websocket closed: %s", msg)
             return False
 
         try:

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -83,7 +83,7 @@ class Websocket:
             try:
                 await self._websocket_loop()
             except ClientError:
-                _LOGGER.debug("Error in websocket reconnect loop, backoff", backoff)
+                _LOGGER.debug("Error in websocket reconnect loop, backoff: %s", backoff)
             except Exception:
                 _LOGGER.debug(
                     "Error in websocket reconnect loop, backoff: %s",

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -86,25 +86,23 @@ class Websocket:
     async def _websocket_reconnect_loop(self) -> None:
         """Reconnect loop for websocket."""
         await self.wait_closed()
+        backoff = self.backoff
 
         while True:
             try:
                 await self._websocket_loop()
-            except ClientError as ex:
-                _LOGGER.debug(
-                    "Error in websocket reconnect loop: %s, backoff", ex, self.backoff
-                )
-                await asyncio.sleep(self.backoff)
+            except ClientError:
+                _LOGGER.debug("Error in websocket reconnect loop, backoff", backoff)
             except Exception:
                 _LOGGER.debug(
                     "Error in websocket reconnect loop, backoff: %s",
-                    self.backoff,
+                    backoff,
                     exc_info=True,
                 )
-                await asyncio.sleep(self.backoff)
 
             if self._running is False:
                 break
+            await asyncio.sleep(self.backoff)
 
     async def _websocket_loop(self) -> None:
         url = self.get_url()

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -21,6 +21,7 @@ from .utils import asyncio_timeout
 _LOGGER = logging.getLogger(__name__)
 AuthCallbackType = Callable[..., Coroutine[Any, Any, Optional[dict[str, str]]]]
 GetSessionCallbackType = Callable[[], Awaitable[ClientSession]]
+_CLOSE_MESSAGE_TYPES = {WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED}
 
 
 class Websocket:
@@ -69,6 +70,9 @@ class Websocket:
         """Process a message from the websocket."""
         if msg.type is WSMsgType.ERROR:
             _LOGGER.exception("Error from Websocket: %s", msg.data)
+            return False
+        elif msg.type in _CLOSE_MESSAGE_TYPES:
+            _LOGGER.debug("Websocket closed")
             return False
 
         try:

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -16,8 +16,6 @@ from aiohttp import (
     WSMsgType,
 )
 
-from .utils import asyncio_timeout
-
 _LOGGER = logging.getLogger(__name__)
 AuthCallbackType = Callable[..., Coroutine[Any, Any, Optional[dict[str, str]]]]
 GetSessionCallbackType = Callable[[], Awaitable[ClientSession]]
@@ -112,13 +110,9 @@ class Websocket:
         # catch any and all errors for Websocket so we can clean up correctly
         try:
             session = await self._get_session()
-            async with asyncio_timeout(self.timeout):
-                self._ws_connection = await session.ws_connect(
-                    url,
-                    ssl=ssl,
-                    headers=self._headers,
-                )
-
+            self._ws_connection = await session.ws_connect(
+                url, ssl=ssl, headers=self._headers, timeout=self.timeout
+            )
             self._last_ws_connect_ok = True
             while True:
                 msg = await self._ws_connection.receive(self.timeout)

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -63,22 +63,6 @@ class Websocket:
         """Return if the websocket is connected."""
         return self._ws_connection is not None and not self._ws_connection.closed
 
-    def _process_message(self, msg: WSMessage) -> bool:
-        """Process a message from the websocket."""
-        if msg.type is WSMsgType.ERROR:
-            _LOGGER.exception("Error from Websocket: %s", msg.data)
-            return False
-        elif msg.type in _CLOSE_MESSAGE_TYPES:
-            _LOGGER.debug("Websocket closed: %s", msg)
-            return False
-
-        try:
-            self._subscription(msg)
-        except Exception:
-            _LOGGER.exception("Error processing websocket message")
-
-        return True
-
     async def _websocket_reconnect_loop(self) -> None:
         """Reconnect loop for websocket."""
         await self.wait_closed()

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
-import time
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
+from functools import partial
 from typing import Any, Optional
 
 from aiohttp import (
@@ -19,9 +20,8 @@ from aiohttp import (
 from .utils import asyncio_timeout
 
 _LOGGER = logging.getLogger(__name__)
-CALLBACK_TYPE = Callable[..., Coroutine[Any, Any, Optional[dict[str, str]]]]
-RECENT_FAILURE_CUT_OFF = 30
-RECENT_FAILURE_THRESHOLD = 2
+AuthCallbackType = Callable[..., Coroutine[Any, Any, Optional[dict[str, str]]]]
+GetSessionCallbackType = Callable[[], Awaitable[ClientSession]]
 
 
 class Websocket:
@@ -29,198 +29,148 @@ class Websocket:
 
     url: str
     verify: bool
-    timeout_interval: int
+    timeout: float
     backoff: int
-    _auth: CALLBACK_TYPE
-    _timeout: float
-    _ws_subscriptions: list[Callable[[WSMessage], None]]
+    _auth: AuthCallbackType
     _connect_lock: asyncio.Lock
+    _running = False
+    _ws_subscriptions: list[Callable[[WSMessage], None]]
 
     _headers: dict[str, str] | None = None
     _websocket_loop_task: asyncio.Task[None] | None = None
-    _timer_task: asyncio.Task[None] | None = None
+    _stop_task: asyncio.Task[None] | None = None
     _ws_connection: ClientWebSocketResponse | None = None
-    _last_connect: float = -1000
-    _recent_failures: int = 0
 
     def __init__(
         self,
         get_url: Callable[[], str],
-        auth_callback: CALLBACK_TYPE,
+        auth_callback: AuthCallbackType,
+        get_session: GetSessionCallbackType,
+        subscription: Callable[[WSMessage], None],
         *,
-        timeout: int = 30,
+        timeout: float = 30.0,
         backoff: int = 10,
         verify: bool = True,
     ) -> None:
         """Init Websocket."""
         self.get_url = get_url
-        self.timeout_interval = timeout
+        self.timeout = timeout
         self.backoff = backoff
         self.verify = verify
+        self._get_session = get_session
         self._auth = auth_callback
-        self._timeout = time.monotonic()
-        self._ws_subscriptions = []
         self._connect_lock = asyncio.Lock()
-
-    @property
-    def is_connected(self) -> bool:
-        """Check if Websocket connected."""
-        return self._ws_connection is not None
-
-    def _get_session(self) -> ClientSession:
-        # for testing, to make easier to mock
-        return ClientSession()
+        self._subscription = subscription
 
     def _process_message(self, msg: WSMessage) -> bool:
-        if msg.type == WSMsgType.ERROR:
+        """Process a message from the websocket."""
+        if msg.type is WSMsgType.ERROR:
             _LOGGER.exception("Error from Websocket: %s", msg.data)
             return False
 
-        for sub in self._ws_subscriptions:
-            try:
-                sub(msg)
-            except Exception:
-                _LOGGER.exception("Error processing websocket message")
+        try:
+            self._subscription(msg)
+        except Exception:
+            _LOGGER.exception("Error processing websocket message")
+
+        # For testing only
+        if self._ws_subscriptions:
+            for subscription in self._ws_subscriptions:
+                try:
+                    subscription(msg)
+                except Exception:
+                    _LOGGER.exception("Error processing websocket subscription")
 
         return True
 
-    async def _websocket_loop(self, start_event: asyncio.Event) -> None:
+    async def _websocket_reconnect_loop(self) -> None:
+        """Reconnect loop for websocket."""
+        await self.wait_closed()
+
+        while True:
+            try:
+                await self._websocket_loop()
+            except Exception:
+                _LOGGER.exception(
+                    "Error in websocket reconnect loop, backoff: %s", self.backoff
+                )
+                await asyncio.sleep(self.backoff)
+
+            if self._running is False:
+                break
+
+    async def _websocket_loop(self) -> None:
         url = self.get_url()
         _LOGGER.debug("Connecting WS to %s", url)
-        self._headers = await self._auth(self._should_reset_auth)
-
-        session = self._get_session()
+        self._headers = await self._auth(False)
+        ssl = None if self.verify else False
         # catch any and all errors for Websocket so we can clean up correctly
         try:
-            self._ws_connection = await session.ws_connect(
-                url,
-                ssl=None if self.verify else False,
-                headers=self._headers,
-            )
-            start_event.set()
+            session = await self._get_session()
+            async with asyncio_timeout(self.timeout):
+                self._ws_connection = await session.ws_connect(
+                    url,
+                    ssl=ssl,
+                    headers=self._headers,
+                )
 
-            self._reset_timeout()
-            async for msg in self._ws_connection:
+            while True:
+                msg = await self._ws_connection.receive(self.timeout)
                 if not self._process_message(msg):
                     break
-                self._reset_timeout()
+        except asyncio.TimeoutError:
+            _LOGGER.debug("Websocket timeout: %s", url)
         except ClientError:
+            self._headers = await self._auth(True)
             _LOGGER.exception("Websocket disconnect error: %s", url)
         finally:
             _LOGGER.debug("Websocket disconnected")
-            self._increase_failure()
-            self._cancel_timeout()
             if self._ws_connection is not None and not self._ws_connection.closed:
                 await self._ws_connection.close()
-            if not session.closed:
-                await session.close()
             self._ws_connection = None
-            # make sure event does not timeout
-            start_event.set()
 
-    @property
-    def has_recent_connect(self) -> bool:
-        """Check if Websocket has recent connection."""
-        return time.monotonic() - RECENT_FAILURE_CUT_OFF <= self._last_connect
-
-    @property
-    def _should_reset_auth(self) -> bool:
-        if self.has_recent_connect:
-            if self._recent_failures > RECENT_FAILURE_THRESHOLD:
-                return True
-        else:
-            self._recent_failures = 0
-        return False
-
-    def _increase_failure(self) -> None:
-        if self.has_recent_connect:
-            self._recent_failures += 1
-        else:
-            self._recent_failures = 1
-
-    async def _do_timeout(self) -> bool:
-        _LOGGER.debug("WS timed out")
-        return await self.reconnect()
-
-    async def _timeout_loop(self) -> None:
-        while True:
-            now = time.monotonic()
-            if now > self._timeout:
-                _LOGGER.debug("WS timed out")
-                if not await self.reconnect():
-                    _LOGGER.debug("WS could not reconnect")
-                    continue
-            sleep_time = self._timeout - now
-            _LOGGER.debug("WS Timeout loop sleep %s", sleep_time)
-            await asyncio.sleep(sleep_time)
-
-    def _reset_timeout(self) -> None:
-        self._timeout = time.monotonic() + self.timeout_interval
-
-        if self._timer_task is None:
-            self._timer_task = asyncio.create_task(self._timeout_loop())
-
-    def _cancel_timeout(self) -> None:
-        if self._timer_task:
-            self._timer_task.cancel()
-
-    async def connect(self) -> bool:
-        """Connect the websocket."""
-        if self._connect_lock.locked():
-            _LOGGER.debug("Another connect is already happening")
-            return False
-        try:
-            async with asyncio_timeout(0.1):
-                await self._connect_lock.acquire()
-        except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
-            _LOGGER.debug("Failed to get connection lock")
-
-        start_event = asyncio.Event()
-        _LOGGER.debug("Scheduling WS connect...")
+    def start(self) -> None:
+        """Start the websocket."""
+        if self._running:
+            return
+        self._running = True
         self._websocket_loop_task = asyncio.create_task(
-            self._websocket_loop(start_event),
+            self._websocket_reconnect_loop()
         )
 
-        try:
-            async with asyncio_timeout(self.timeout_interval):
-                await start_event.wait()
-        except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
-            _LOGGER.warning("Timed out while waiting for Websocket to connect")
-            await self.disconnect()
-
-        self._connect_lock.release()
-        if self._ws_connection is None:
-            _LOGGER.debug("Failed to connect to Websocket")
-            return False
-        _LOGGER.debug("Connected to Websocket successfully")
-        self._last_connect = time.monotonic()
-        return True
-
-    async def disconnect(self) -> None:
+    def stop(self) -> None:
         """Disconnect the websocket."""
-        _LOGGER.debug("Disconnecting websocket...")
-        if self._ws_connection is None:
+        if not self._running:
             return
-        await self._ws_connection.close()
-        self._ws_connection = None
+        _LOGGER.debug("Disconnecting websocket...")
+        if self._websocket_loop_task:
+            self._websocket_loop_task.cancel()
+        self._running = False
+        self._stop_task = asyncio.create_task(self._stop())
 
-    async def reconnect(self) -> bool:
-        """Reconnect the websocket."""
-        _LOGGER.debug("Reconnecting websocket...")
-        await self.disconnect()
-        await asyncio.sleep(self.backoff)
-        return await self.connect()
+    async def wait_closed(self) -> None:
+        """Wait for the websocket to close."""
+        if self._stop_task:
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._stop_task
 
-    def subscribe(self, ws_callback: Callable[[WSMessage], None]) -> Callable[[], None]:
-        """
-        Subscribe to raw websocket messages.
+    async def _stop(self) -> None:
+        """Stop the websocket."""
+        if self._ws_connection:
+            await self._ws_connection.close()
+            self._ws_connection = None
+        if self._websocket_loop_task:
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._websocket_loop_task
+            self._websocket_loop_task = None
 
-        Returns a callback that will unsubscribe.
-        """
+    def subscribe(
+        self, subscription: Callable[[WSMessage], None]
+    ) -> Callable[[], None]:
+        """Subscribe to websocket messages."""
+        self._ws_subscriptions.append(subscription)
+        return partial(self._unsubscribe, subscription)
 
-        def _unsub_ws_callback() -> None:
-            self._ws_subscriptions.remove(ws_callback)
-
-        _LOGGER.debug("Adding subscription: %s", ws_callback)
-        self._ws_subscriptions.append(ws_callback)
-        return _unsub_ws_callback
+    def _unsubscribe(self, subscription: Callable[[WSMessage], None]) -> None:
+        """Unsubscribe to websocket messages."""
+        self._ws_subscriptions.remove(subscription)

--- a/src/uiprotect/websocket.py
+++ b/src/uiprotect/websocket.py
@@ -25,14 +25,7 @@ _CLOSE_MESSAGE_TYPES = {WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED}
 class Websocket:
     """UniFi Protect Websocket manager."""
 
-    url: str
-    verify: bool
-    timeout: float
-    backoff: int
-    _auth: AuthCallbackType
-    _connect_lock: asyncio.Lock
     _running = False
-
     _headers: dict[str, str] | None = None
     _websocket_loop_task: asyncio.Task[None] | None = None
     _stop_task: asyncio.Task[None] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,6 +225,9 @@ class SimpleMockWebsocket:
             None,
         )
 
+    async def receive(self, timeout):
+        return await self.__anext__()
+
 
 class MockWebsocket(SimpleMockWebsocket):
     def __init__(self):
@@ -248,13 +251,13 @@ async def setup_client(
     websocket: SimpleMockWebsocket,
     timeout: int = 0,
 ):
-    mock_cs = Mock()
+    mock_cs = AsyncMock()
     mock_session = AsyncMock()
     mock_session.ws_connect = AsyncMock(return_value=websocket)
     mock_cs.return_value = mock_session
 
-    ws = await client.get_websocket()
-    ws.timeout_interval = timeout
+    ws = client._get_websocket()
+    ws.timeout = timeout
     ws._get_session = mock_cs  # type: ignore[method-assign]
     client.api_request = AsyncMock(side_effect=mock_api_request)  # type: ignore[method-assign]
     client.api_request_raw = AsyncMock(side_effect=mock_api_request_raw)  # type: ignore[method-assign]

--- a/tests/test_api_polling.py
+++ b/tests/test_api_polling.py
@@ -81,7 +81,7 @@ async def test_process_events_ring(protect_client: ProtectApiClient, now, camera
 
     protect_client._last_update = NEVER_RAN
     await protect_client.update()  # fetch initial bootstrap
-    await protect_client.update()  # process events since bootstrap
+    await protect_client.poll_events()  # process events since bootstrap
 
     camera = get_camera()
 
@@ -130,7 +130,7 @@ async def test_process_events_motion(protect_client: ProtectApiClient, now, came
 
     protect_client._last_update = NEVER_RAN
     await protect_client.update()  # fetch initial bootstrap
-    await protect_client.update()  # process events since bootstrap
+    await protect_client.poll_events()  # process events since bootstrap
 
     camera_before.is_motion_detected = False
     camera = get_camera()
@@ -181,7 +181,7 @@ async def test_process_events_smart(protect_client: ProtectApiClient, now, camer
 
     protect_client._last_update = NEVER_RAN
     await protect_client.update()  # fetch initial bootstrap
-    await protect_client.update()  # process events since bootstrap
+    await protect_client.poll_events()  # process events since bootstrap
 
     camera = get_camera()
 


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Take the websocket logic out of the update logic, instead to connect the websocket when subscriptions are made.

BREAKING CHANGE: You must call `api.update` before subscribing to the websocket with `api.subscribe_websocket`
BREAKING CHANGE: fallback to event polling is no longer done automatically since it causes messages to get out of sync with the websocket. Manual event polling can be achieved with `api.poll_events`, but its not recommended and is only left for backwards compat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved websocket connection handling and management for more efficient and reliable performance.
  - Enhanced subscription and unsubscription logic for better resource management.

- **New Features**
  - Added event polling functionality to improve real-time updates and responsiveness.
  - Introduced methods to control the lifecycle of websocket connections, including start, stop, and reconnect capabilities.

- **Bug Fixes**
  - Addressed issues with websocket connection status checks and error handling to ensure more stable operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->