### PR TITLE
feat!: remove the force flag from update

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -75,7 +75,6 @@ if sys.version_info[:2] < (3, 13):
 
 TOKEN_COOKIE_MAX_EXP_SECONDS = 60
 
-NEVER_RAN = -1000
 # how many seconds before the bootstrap is refreshed from Protect
 DEVICE_UPDATE_INTERVAL = 900
 # retry timeout for thumbnails/heatmaps

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -286,13 +286,13 @@ def test_connection_host_override():
 async def test_force_update(protect_client: ProtectApiClient):
     protect_client._bootstrap = None
 
-    await protect_client.update(force=True)
+    await protect_client.update()
 
     assert protect_client.bootstrap
     original_bootstrap = protect_client.bootstrap
     protect_client._bootstrap = None
     with patch("uiprotect.api.ProtectApiClient.get_bootstrap", AsyncMock()) as mock:
-        await protect_client.update(force=False)
+        await protect_client.update()
         assert mock.called
 
     assert protect_client.bootstrap

--- a/tests/test_api_polling.py
+++ b/tests/test_api_polling.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import pytest
 
 from tests.conftest import MockDatetime
-from uiprotect.api import NEVER_RAN
 from uiprotect.data import Camera, EventType
 from uiprotect.utils import to_js_time
 
@@ -79,7 +78,6 @@ async def test_process_events_ring(protect_client: ProtectApiClient, now, camera
 
     protect_client.get_events_raw = get_events  # type: ignore[method-assign]
 
-    protect_client._last_update = NEVER_RAN
     await protect_client.update()  # fetch initial bootstrap
     await protect_client.poll_events()  # process events since bootstrap
 
@@ -128,7 +126,6 @@ async def test_process_events_motion(protect_client: ProtectApiClient, now, came
 
     protect_client.get_events_raw = get_events  # type: ignore[method-assign]
 
-    protect_client._last_update = NEVER_RAN
     await protect_client.update()  # fetch initial bootstrap
     await protect_client.poll_events()  # process events since bootstrap
 
@@ -179,7 +176,6 @@ async def test_process_events_smart(protect_client: ProtectApiClient, now, camer
 
     protect_client.get_events_raw = get_events  # type: ignore[method-assign]
 
-    protect_client._last_update = NEVER_RAN
     await protect_client.update()  # fetch initial bootstrap
     await protect_client.poll_events()  # process events since bootstrap
 


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

calling update always now always does an update instead of having to guess if one will happen or not. This will allow us to remove all sorts of complex logic 