### PR TITLE
fix: _raise_for_status when raise_exception is not set

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -411,11 +411,13 @@ class BaseApiClient:
     async def _raise_for_status(
         self, response: aiohttp.ClientResponse, raise_exception: bool = True
     ) -> None:
+        """Raise an exception based on the response status."""
         url = response.url
         reason = await get_response_reason(response)
         msg = "Request failed: %s - Status: %s - Reason: %s"
+        status = response.status
+
         if raise_exception:
-            status = response.status
             if status in {
                 HTTPStatus.UNAUTHORIZED.value,
                 HTTPStatus.FORBIDDEN.value,
@@ -430,6 +432,7 @@ class BaseApiClient:
             ):
                 raise BadRequest(msg % (url, status, reason))
             raise NvrError(msg % (url, status, reason))
+
         _LOGGER.debug(msg, url, status, reason)
 
     async def api_request(


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
_raise_for_status when raise_exception is not set

status would be unbound in this case