### PR TITLE
fix: coveragerc fails to omit cli and tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,11 +2,16 @@
 source = src/uiprotect
 
 omit =
-    site
+    site/*
     src/uiprotect/cli/*
     src/uiprotect/test_util/*
 
 [report]
+omit =
+    site/*
+    src/uiprotect/cli/*
+    src/uiprotect/test_util/*
+
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
coveragerc fails to omit cli and tests.

I went to start looking as what was missing coverage in base.py and realized the coveragerc didn't work as expected