### PR TITLE
fix: ensure test harness does not delete coveragerc

### DIFF
--- a/.bin/test-code
+++ b/.bin/test-code
@@ -13,7 +13,7 @@ PYTEST_EXTRA_ARGS="${PYTEST_EXTRA_ARGS:-}"
 
 pushd "$ROOT_PATH" 2>&1 >/dev/null
 
-rm -rf .coverage*
+rm -rf .coverage.* .coverage
 
 echo -e "\nRunning tests (no benchmarks)..."
 poetry run pytest --timeout=10 --color=yes --cov-report=xml --benchmark-skip --maxfail=10 $PYTEST_EXTRA_ARGS


### PR DESCRIPTION


### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
The test harness deleted all the coverage files when it ran but it also deleted .coveragerc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup process by ensuring the removal of all coverage files after tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->