### PR TITLE
fix: make creation of update sync primitives lazy

### DIFF
--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -159,10 +159,9 @@ class Light(ProtectMotionDeviceModel):
 
     async def set_paired_camera(self, camera: Camera | None) -> None:
         """Sets the camera paired with the light"""
-        async with self._update_lock:
-            await asyncio.sleep(
-                0,
-            )  # yield to the event loop once we have the lock to process any pending updates
+        async with self._update_sync.lock:
+            # yield to the event loop once we have the lock to process any pending updates
+            await asyncio.sleep(0)
             data_before_changes = self.dict_with_excludes()
             if camera is None:
                 self.camera_id = None
@@ -2378,10 +2377,9 @@ class Camera(ProtectMotionDeviceModel):
             raise BadRequest("Camera does not have an LCD screen")
 
         if text_type is None:
-            async with self._update_lock:
-                await asyncio.sleep(
-                    0,
-                )  # yield to the event loop once we have the lock to process any pending updates
+            async with self._update_sync.lock:
+                # yield to the event loop once we have the lock to process any pending updates
+                await asyncio.sleep(0)
                 data_before_changes = self.dict_with_excludes()
                 self.lcd_message = None
                 # UniFi Protect bug: clearing LCD text message does _not_ emit a WS message
@@ -2704,10 +2702,9 @@ class Viewer(ProtectAdoptableDeviceModel):
         if self._api is not None and liveview.id not in self._api.bootstrap.liveviews:
             raise BadRequest("Unknown liveview")
 
-        async with self._update_lock:
-            await asyncio.sleep(
-                0,
-            )  # yield to the event loop once we have the lock to process any pending updates
+        async with self._update_sync.lock:
+            # yield to the event loop once we have the lock to process any pending updates
+            await asyncio.sleep(0)
             data_before_changes = self.dict_with_excludes()
             self.liveview_id = liveview.id
             # UniFi Protect bug: changing the liveview does _not_ emit a WS message

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -1184,7 +1184,7 @@ class NVR(ProtectDeviceModel):
         self, update_callback: Callable[[], None]
     ) -> None:
         """Updates doorbell messages and saves to Protect."""
-        async with self._update_lock:
+        async with self._update_sync.lock:
             # yield to the event loop once we have the lock to ensure websocket updates are processed
             await asyncio.sleep(0)
             data_before_changes = self.dict_with_excludes()


### PR DESCRIPTION


### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
every object had an asyncio.Queue, asyncio.Lock, and asyncio.Event only create them the first time they are needed
