### PR TITLE
fix: remove unreachable code in the websocket decoder

### DIFF
--- a/src/uiprotect/data/websocket.py
+++ b/src/uiprotect/data/websocket.py
@@ -204,10 +204,9 @@ class WSPacket:
     def action_frame(self) -> BaseWSPacketFrame:
         if self._action_frame is None:
             self.decode()
-
-        if self._action_frame is None:
-            raise WSDecodeError("Packet unexpectedly not decoded")
-
+        if TYPE_CHECKING:
+            assert self._action_frame is not None
+            assert self._data_frame is not None
         self.__dict__["data_frame"] = self._data_frame
         return self._action_frame
 
@@ -215,10 +214,9 @@ class WSPacket:
     def data_frame(self) -> BaseWSPacketFrame:
         if self._data_frame is None:
             self.decode()
-
-        if self._data_frame is None:
-            raise WSDecodeError("Packet unexpectedly not decoded")
-
+        if TYPE_CHECKING:
+            assert self._action_frame is not None
+            assert self._data_frame is not None
         self.__dict__["action_frame"] = self._action_frame
         return self._data_frame
 


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
fix: remove unreachable code in the websocket decoder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of WebSocket protocol by adding type checks for incoming data frames, ensuring more robust data handling and reducing potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->