### PR TITLE
feat: reduce duplicate code to do unifi_dict_to_dict conversions

### DIFF
--- a/src/uiprotect/data/base.py
+++ b/src/uiprotect/data/base.py
@@ -310,8 +310,8 @@ class ProtectBaseObject(BaseModel):
 
         conversions = cls.unifi_dict_conversions()
         for key, convert in conversions.items():
-            if key in data and data[key] is not None:
-                data[key] = convert(data[key])  # type: ignore[operator]
+            if (val := data.get(key)) is not None:
+                data[key] = convert(val)  # type: ignore[operator]
 
         remaps = cls._get_unifi_remaps()
         # convert to snake_case and remove extra fields

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -107,11 +107,11 @@ class LightDeviceSettings(ProtectBaseObject):
     pir_sensitivity: PercentInt
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "pirDuration" in data and not isinstance(data["pirDuration"], timedelta):
-            data["pirDuration"] = timedelta(milliseconds=data["pirDuration"])
-
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "pirDuration": lambda x: timedelta(milliseconds=x)
+        } | super().unifi_dict_conversions()
 
 
 class LightOnSettings(ProtectBaseObject):

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -657,7 +657,7 @@ class CameraZone(ProtectBaseObject):
     @cache
     def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
         return {
-            "points": lambda x: [(p[0], p[1]) for p in x["points"]],
+            "points": lambda x: [(p[0], p[1]) for p in x],
         } | super().unifi_dict_conversions()
 
     def unifi_dict(
@@ -1020,13 +1020,17 @@ class Camera(ProtectMotionDeviceModel):
         }
 
     @classmethod
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "chimeDuration": lambda x: timedelta(milliseconds=x),
+        } | super().unifi_dict_conversions()
+
+    @classmethod
     def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
         # LCD messages comes back as empty dict {}
         if "lcdMessage" in data and len(data["lcdMessage"]) == 0:
             del data["lcdMessage"]
-        if "chimeDuration" in data and not isinstance(data["chimeDuration"], timedelta):
-            data["chimeDuration"] = timedelta(milliseconds=data["chimeDuration"])
-
         return super().unifi_dict_to_dict(data)
 
     def unifi_dict(

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from functools import cache
 from ipaddress import IPv4Address
@@ -654,12 +654,11 @@ class CameraZone(ProtectBaseObject):
     points: list[tuple[Percent, Percent]]
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        data = super().unifi_dict_to_dict(data)
-        if "points" in data and isinstance(data["points"], Iterable):
-            data["points"] = [(p[0], p[1]) for p in data["points"]]
-
-        return data
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "points": lambda x: [(p[0], p[1]) for p in x["points"]],
+        } | super().unifi_dict_conversions()
 
     def unifi_dict(
         self,

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -3090,14 +3090,11 @@ class Doorlock(ProtectAdoptableDeviceModel):
         }
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "autoCloseTimeMs" in data and not isinstance(
-            data["autoCloseTimeMs"],
-            timedelta,
-        ):
-            data["autoCloseTimeMs"] = timedelta(milliseconds=data["autoCloseTimeMs"])
-
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "autoCloseTimeMs": lambda x: timedelta(milliseconds=x)
+        } | super().unifi_dict_conversions()
 
     @property
     def camera(self) -> Camera | None:

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -401,6 +401,14 @@ class RecordingSettings(ProtectBaseObject):
         }
 
     @classmethod
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "minMotionEventTrigger": lambda x: timedelta(seconds=x),
+            "endMotionEventDelay": lambda x: timedelta(seconds=x),
+        } | super().unifi_dict_conversions()
+
+    @classmethod
     def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
         if "prePaddingSecs" in data:
             data["prePadding"] = timedelta(seconds=data.pop("prePaddingSecs"))
@@ -414,18 +422,6 @@ class RecordingSettings(ProtectBaseObject):
             data["smartDetectPostPadding"] = timedelta(
                 seconds=data.pop("smartDetectPostPaddingSecs"),
             )
-        if "minMotionEventTrigger" in data and not isinstance(
-            data["minMotionEventTrigger"],
-            timedelta,
-        ):
-            data["minMotionEventTrigger"] = timedelta(
-                seconds=data["minMotionEventTrigger"],
-            )
-        if "endMotionEventDelay" in data and not isinstance(
-            data["endMotionEventDelay"],
-            timedelta,
-        ):
-            data["endMotionEventDelay"] = timedelta(seconds=data["endMotionEventDelay"])
 
         return super().unifi_dict_to_dict(data)
 

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -703,11 +703,11 @@ class UOSSpace(ProtectBaseObject):
         }
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "estimate" in data and data["estimate"] is not None:
-            data["estimate"] = timedelta(seconds=data.pop("estimate"))
-
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "estimate": lambda x: timedelta(seconds=x)
+        } | super().unifi_dict_conversions()
 
     def unifi_dict(
         self,

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -301,11 +301,12 @@ class Event(ProtectModelWithId):
         }
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        for key in ("start", "end", "timestamp", "deletedAt"):
-            if key in data:
-                data[key] = convert_to_datetime(data[key])
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            key: convert_to_datetime
+            for key in ("start", "end", "timestamp", "deletedAt")
+        } | super().unifi_dict_conversions()
 
     def unifi_dict(
         self,

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -1016,19 +1016,9 @@ class NVR(ProtectDeviceModel):
             "lastUpdateAt": convert_to_datetime,
             "lastDeviceFwUpdatesCheckedAt": convert_to_datetime,
             "timezone": zoneinfo.ZoneInfo,
+            # recordingRetentionDurationMs is remapped to recordingRetentionDuration
+            "recordingRetentionDurationMs": lambda x: timedelta(milliseconds=x),
         } | super().unifi_dict_conversions()
-
-    @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if (
-            "recordingRetentionDurationMs" in data
-            and data["recordingRetentionDurationMs"] is not None
-        ):
-            data["recordingRetentionDuration"] = timedelta(
-                milliseconds=data.pop("recordingRetentionDurationMs"),
-            )
-
-        return super().unifi_dict_to_dict(data)
 
     async def _api_update(self, data: dict[str, Any]) -> None:
         return await self._api.update_nvr(data)

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -1010,13 +1010,16 @@ class NVR(ProtectDeviceModel):
         }
 
     @classmethod
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "lastUpdateAt": convert_to_datetime,
+            "lastDeviceFwUpdatesCheckedAt": convert_to_datetime,
+            "timezone": zoneinfo.ZoneInfo,
+        } | super().unifi_dict_conversions()
+
+    @classmethod
     def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "lastUpdateAt" in data:
-            data["lastUpdateAt"] = convert_to_datetime(data["lastUpdateAt"])
-        if "lastDeviceFwUpdatesCheckedAt" in data:
-            data["lastDeviceFwUpdatesCheckedAt"] = convert_to_datetime(
-                data["lastDeviceFwUpdatesCheckedAt"]
-            )
         if (
             "recordingRetentionDurationMs" in data
             and data["recordingRetentionDurationMs"] is not None
@@ -1024,8 +1027,6 @@ class NVR(ProtectDeviceModel):
             data["recordingRetentionDuration"] = timedelta(
                 milliseconds=data.pop("recordingRetentionDurationMs"),
             )
-        if "timezone" in data and not isinstance(data["timezone"], tzinfo):
-            data["timezone"] = zoneinfo.ZoneInfo(data["timezone"])
 
         return super().unifi_dict_to_dict(data)
 

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -766,13 +766,12 @@ class DoorbellSettings(ProtectBaseObject):
         }
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "defaultMessageResetTimeoutMs" in data:
-            data["defaultMessageResetTimeout"] = timedelta(
-                milliseconds=data.pop("defaultMessageResetTimeoutMs"),
-            )
-
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            # defaultMessageResetTimeoutMs is remapped to defaultMessageResetTimeout
+            "defaultMessageResetTimeoutMs": lambda x: timedelta(milliseconds=x),
+        } | super().unifi_dict_conversions()
 
 
 class RecordingTypeDistribution(ProtectBaseObject):

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -619,11 +619,11 @@ class UOSDisk(ProtectBaseObject):
         }
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "estimate" in data and data["estimate"] is not None:
-            data["estimate"] = timedelta(seconds=data.pop("estimate"))
-
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "estimate": lambda x: timedelta(seconds=x)
+        } | super().unifi_dict_conversions()
 
     def unifi_dict(
         self,

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -94,11 +94,11 @@ class SmartDetectItem(ProtectBaseObject):
         }
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "duration" in data:
-            data["duration"] = timedelta(milliseconds=data["duration"])
-
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "duration": lambda x: timedelta(milliseconds=x),
+        } | super().unifi_dict_conversions()
 
 
 class SmartDetectTrack(ProtectBaseObject):
@@ -161,14 +161,9 @@ class EventDetectedThumbnail(ProtectBaseObject):
     name: str | None
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "clockBestWall" in data:
-            if data["clockBestWall"]:
-                data["clockBestWall"] = convert_to_datetime(data["clockBestWall"])
-            else:
-                del data["clockBestWall"]
-
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {"clockBestWall": convert_to_datetime} | super().unifi_dict_conversions()
 
     def unifi_dict(
         self,
@@ -865,15 +860,12 @@ class StorageStats(ProtectBaseObject):
     storage_distribution: StorageDistribution
 
     @classmethod
-    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if "capacity" in data and data["capacity"] is not None:
-            data["capacity"] = timedelta(milliseconds=data.pop("capacity"))
-        if "remainingCapacity" in data and data["remainingCapacity"] is not None:
-            data["remainingCapacity"] = timedelta(
-                milliseconds=data.pop("remainingCapacity"),
-            )
-
-        return super().unifi_dict_to_dict(data)
+    @cache
+    def unifi_dict_conversions(cls) -> dict[str, object | Callable[[Any], Any]]:
+        return {
+            "capacity": lambda x: timedelta(milliseconds=x),
+            "remainingCapacity": lambda x: timedelta(milliseconds=x),
+        } | super().unifi_dict_conversions()
 
 
 class NVRFeatureFlags(ProtectBaseObject):


### PR DESCRIPTION


### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
reduce duplicate code to do unifi_dict_to_dict conversions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved data conversion methods to enhance code readability and maintainability.
  - Centralized conversion logic for handling keys like "upSince", "uptime", "lastSeen", and others across various device settings.

- **Performance**
  - Added caching mechanisms to improve efficiency in data processing.

- **Bug Fixes**
  - Fixed inconsistencies in data handling for device-specific keys like "pirDuration", "audioTypes", "objectTypes", and more.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->