### PR TITLE
feat!: remove is_ringing property and ring ping back from camera

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -464,13 +464,6 @@ class Bootstrap(ProtectBaseObject):
             if TYPE_CHECKING:
                 assert isinstance(obj, Event)
             self.process_event(obj)
-        elif model_type is ModelType.CAMERA:
-            if TYPE_CHECKING:
-                assert isinstance(obj, Camera)
-            if "last_ring" in data and (last_ring := obj.last_ring):
-                if is_recent := last_ring + RECENT_EVENT_MAX >= utc_now():
-                    obj.set_ring_timeout()
-                _LOGGER.debug("last_ring for %s (%s)", obj.id, is_recent)
         elif model_type is ModelType.SENSOR:
             if TYPE_CHECKING:
                 assert isinstance(obj, Sensor)

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -977,7 +977,6 @@ class Camera(ProtectMotionDeviceModel):
     last_smart_detect_event_ids: dict[SmartDetectObjectType, str] = {}
     last_smart_audio_detect_event_ids: dict[SmartDetectAudioType, str] = {}
     talkback_stream: TalkbackStream | None = None
-    _last_ring_timeout: datetime | None = PrivateAttr(None)
 
     @classmethod
     @cache
@@ -1846,12 +1845,6 @@ class Camera(ProtectMotionDeviceModel):
     # endregion
 
     @property
-    def is_ringing(self) -> bool:
-        if self._last_ring_timeout is None:
-            return False
-        return utc_now() < self._last_ring_timeout
-
-    @property
     def chime_type(self) -> ChimeType:
         if self.chime_duration.total_seconds() == 0.3:
             return ChimeType.MECHANICAL
@@ -1934,10 +1927,6 @@ class Camera(ProtectMotionDeviceModel):
             return is_attached
 
         return False
-
-    def set_ring_timeout(self) -> None:
-        self._last_ring_timeout = utc_now() + EVENT_PING_INTERVAL
-        self._event_callback_ping()
 
     def get_privacy_zone(self) -> tuple[int | None, CameraZone | None]:
         for index, zone in enumerate(self.privacy_zones):


### PR DESCRIPTION

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
The ring sensors in Home Assistant are now event driven to
better match the protect model which means this property
is no longer used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed ring timeout handling and related logic from camera events.
	- Renamed and updated test cases to reflect changes from ring events to alarm events.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->