### PR TITLE
feat!: do not auto convert enums to values for fetching attrs

### DIFF
--- a/src/uiprotect/__init__.py
+++ b/src/uiprotect/__init__.py
@@ -7,7 +7,6 @@ from .exceptions import Invalid, NotAuthorized, NvrError
 from .utils import (
     get_nested_attr,
     get_nested_attr_as_bool,
-    get_top_level_attr,
     get_top_level_attr_as_bool,
     make_enabled_getter,
     make_required_getter,
@@ -21,7 +20,6 @@ __all__ = [
     "ProtectApiClient",
     "get_nested_attr",
     "get_nested_attr_as_bool",
-    "get_top_level_attr",
     "get_top_level_attr_as_bool",
     "make_value_getter",
     "make_enabled_getter",

--- a/src/uiprotect/utils.py
+++ b/src/uiprotect/utils.py
@@ -634,7 +634,7 @@ def get_nested_attr(attrs: tuple[str, ...], obj: Any) -> Any:
     for key in attrs:
         if (value := getattr(value, key, _SENTINEL)) is _SENTINEL:
             return None
-    return value.value if isinstance(value, Enum) else value
+    return value
 
 
 def get_nested_attr_as_bool(attrs: tuple[str, ...], obj: Any) -> bool:
@@ -643,25 +643,18 @@ def get_nested_attr_as_bool(attrs: tuple[str, ...], obj: Any) -> bool:
     for key in attrs:
         if (value := getattr(value, key, _SENTINEL)) is _SENTINEL:
             return False
-    return bool(value.value if isinstance(value, Enum) else value)
-
-
-def get_top_level_attr(attr: str, obj: Any) -> Any:
-    """Fetch a top level attribute."""
-    value = getattr(obj, attr)
-    return value.value if isinstance(value, Enum) else value
+    return bool(value)
 
 
 def get_top_level_attr_as_bool(attr: str, obj: Any) -> Any:
     """Fetch a top level attribute as a bool."""
-    value = getattr(obj, attr)
-    return bool(value.value if isinstance(value, Enum) else value)
+    return bool(getattr(obj, attr))
 
 
 def make_value_getter(ufp_value: str) -> Callable[[T], Any]:
     """Return a function to get a value from a Protect device."""
     if "." not in ufp_value:
-        return partial(get_top_level_attr, ufp_value)
+        return attrgetter(ufp_value)
     return partial(get_nested_attr, tuple(ufp_value.split(".")))
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,6 @@ from uiprotect.utils import (
     dict_diff,
     get_nested_attr,
     get_nested_attr_as_bool,
-    get_top_level_attr,
     get_top_level_attr_as_bool,
     make_enabled_getter,
     make_required_getter,
@@ -219,7 +218,7 @@ def test_get_nested_attr():
     data = Mock(a=Mock(b=Mock(c=1)), d=3, f=_MockEnum.C)
     assert get_nested_attr(("a", "b", "c"), data) == 1
     assert get_nested_attr(("d",), data) == 3
-    assert get_nested_attr(("f",), data) == _MockEnum.C.value
+    assert get_nested_attr(("f",), data) == _MockEnum.C
 
 
 @pytest.mark.asyncio
@@ -231,17 +230,8 @@ def test_get_nested_attr_as_bool():
 
 
 @pytest.mark.asyncio
-def test_get_top_level_attr():
-    data = Mock(a=1, b=2, c=3, d=_MockEnum.C)
-    assert get_top_level_attr("a", data) == 1
-    assert get_top_level_attr("b", data) == 2
-    assert get_top_level_attr("c", data) == 3
-    assert get_top_level_attr("d", data) == _MockEnum.C.value
-
-
-@pytest.mark.asyncio
 def test_get_top_level_attr_as_bool():
-    data = Mock(a=True, b=False, c=_MockEnum.C, d=None)
+    data = Mock(a=True, b=False, c=True, d=None)
     assert get_top_level_attr_as_bool("a", data) is True
     assert get_top_level_attr_as_bool("b", data) is False
     assert get_top_level_attr_as_bool("c", data) is True
@@ -250,11 +240,11 @@ def test_get_top_level_attr_as_bool():
 
 @pytest.mark.asyncio
 def test_make_value_getter():
-    data = Mock(a=1, b=2, c=3, d=_MockEnum.C)
+    data = Mock(a=1, b=2, c=3, d=4)
     assert make_value_getter("a")(data) == 1
     assert make_value_getter("b")(data) == 2
     assert make_value_getter("c")(data) == 3
-    assert make_value_getter("d")(data) == _MockEnum.C.value
+    assert make_value_getter("d")(data) == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
The attrgetters no longer auto convert enums to their values

The objects we care about are str enums so convert should not be needed

I may have missed one but if so we can make a new function for it so we don't have to do the enum check for a case where 99%+ of the time is not needed (sometimes 10000+/min)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `get_top_level_attr` function from the public interface to streamline functionality.
  - Simplified logic in `get_nested_attr` and `get_nested_attr_as_bool` functions for improved performance.
  
- **Tests**
  - Updated test cases by removing `get_top_level_attr` references and adjusting assertions for `get_nested_attr` and boolean checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->