### PR TITLE
feat: remove deepcopy before calling update_from_dict

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -399,7 +398,7 @@ class Bootstrap(ProtectBaseObject):
             return None
 
         old_nvr = self.nvr.copy()
-        self.nvr = self.nvr.update_from_dict(deepcopy(data))
+        self.nvr = self.nvr.update_from_dict(data)
 
         return WSSubscriptionMessage(
             action=WSAction.UPDATE,
@@ -455,7 +454,7 @@ class Bootstrap(ProtectBaseObject):
             return None
 
         old_obj = obj.copy()
-        obj = obj.update_from_dict(deepcopy(data))
+        obj = obj.update_from_dict(data)
 
         if model_type is ModelType.EVENT:
             if TYPE_CHECKING:

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -1090,11 +1090,12 @@ class Camera(ProtectMotionDeviceModel):
         return updated
 
     def update_from_dict(self, data: dict[str, Any]) -> Camera:
-        # a message in the past is actually a singal to wipe the message
-        reset_at = data.get("lcd_message", {}).get("reset_at")
-        if reset_at is not None:
-            reset_at = from_js_time(reset_at)
-            if utc_now() > reset_at:
+        # a message in the past is actually a signal to wipe the message
+        if (reset_at := data.get("lcd_message", {}).get("reset_at")) is not None:
+            if utc_now() > from_js_time(reset_at):
+                # Important: Make a copy of the data before modifying it
+                # since unifi_dict_to_dict will otherwise report incorrect changes
+                data = data.copy()
                 data["lcd_message"] = None
 
         return super().update_from_dict(data)


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
There was only one place in update_from_dict that mutates the data so instead copy it there instead of every time


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of message reset conditions for Camera updates to ensure accurate status reporting.

- **Refactor**
  - Removed redundant deep copy operations to enhance performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->