### PR TITLE
fix: avoid reflecting back SMOKE_CMONX when changing smart audio

### DIFF
--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -471,6 +471,20 @@ class SmartDetectSettings(ProtectBaseObject):
             "autoTrackingObjectTypes": convert_smart_types,
         } | super().unifi_dict_conversions()
 
+    def unifi_dict(
+        self,
+        data: dict[str, Any] | None = None,
+        exclude: set[str] | None = None,
+    ) -> dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
+        if audio_types := data.get("audioTypes"):
+            # SMOKE_CMONX is not supported for audio types
+            # and should not be sent to the camera
+            data["audioTypes"] = [
+                t for t in audio_types if t != SmartDetectAudioType.SMOKE_CMONX.value
+            ]
+        return data
+
 
 class LCDMessage(ProtectBaseObject):
     type: DoorbellMessageType


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
This value is never reflected back by the UI client and will prevent changing smoke/CO detections if sent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to manipulate audio types in device data.
- **Tests**
	- Added new unit tests for smart audio detection settings in camera configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->