### PR TITLE
fix: reflection of chime duration seconds

### DIFF
--- a/src/uiprotect/utils.py
+++ b/src/uiprotect/utils.py
@@ -670,3 +670,8 @@ def make_required_getter(ufp_required_field: str) -> Callable[[T], bool]:
     if "." not in ufp_required_field:
         return partial(get_top_level_attr_as_bool, ufp_required_field)
     return partial(get_nested_attr_as_bool, tuple(ufp_required_field.split(".")))
+
+
+@lru_cache
+def timedelta_total_seconds(td: timedelta) -> float:
+    return td.total_seconds()

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -495,7 +495,8 @@ async def test_camera_set_chime_duration_duration(
     camera_obj.api.api_request.reset_mock()
 
     camera_obj.feature_flags.has_chime = True
-    camera_obj.chime_duration = 300
+    camera_obj.chime_duration = timedelta(seconds=300)
+    assert camera_obj.chime_duration_seconds == 300
     camera_obj.mic_volume = 10
 
     if duration in {-1, 20}:


### PR DESCRIPTION

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
The mocking in the test was using an int instead
of a timedelta. Add new property to
get the seconds
