### PR TITLE
chore: start testing with python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         os:
           - ubuntu-latest
         pydantic:
@@ -61,6 +62,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
+          allow-prereleases: true
       - run: echo "Cache hit:${{ steps.setup-python.outputs.cache-hit }}" # true if cache-hit occurred on the primary key
       - name: Install Dependencies
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI workflow to include Python version 3.13 for enhanced testing coverage.
	- Modified the environment setup to allow installation of pre-release package versions, improving dependency management flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->