### PR TITLE
feat: speed up url joins

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -391,7 +391,7 @@ class BaseApiClient:
         """Make a request to UniFi Protect API"""
         response = await self.request(
             method,
-            f"{self.api_path}/{url}",
+            f"{self.api_path}{url}",
             require_auth=require_auth,
             auto_close=False,
             **kwargs,
@@ -1543,7 +1543,7 @@ class ProtectApiClient(BaseApiClient):
 
         r = await self.request(
             "get",
-            f"{self.api_path}/{path}",
+            f"{self.api_path}{path}",
             auto_close=False,
             timeout=0,
             params=params,

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -17,7 +17,7 @@ from http.cookies import Morsel, SimpleCookie
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
 from typing import Any, Literal, cast
-from urllib.parse import urljoin
+from urllib.parse import SplitResult
 
 import aiofiles
 import aiohttp
@@ -327,7 +327,9 @@ class BaseApiClient:
         if require_auth:
             await self.ensure_authenticated()
 
-        request_url = self._url.joinpath(url[1:])
+        request_url = self._url.join(
+            URL(SplitResult("", "", url, "", ""), encoded=True)
+        )
         headers = kwargs.get("headers") or self.headers
         _LOGGER.debug("Request url: %s", request_url)
         if not self._verify_ssl:
@@ -387,10 +389,9 @@ class BaseApiClient:
         **kwargs: Any,
     ) -> bytes | None:
         """Make a request to UniFi Protect API"""
-        url = urljoin(self.api_path, url)
         response = await self.request(
             method,
-            url,
+            f"{self.api_path}/{url}",
             require_auth=require_auth,
             auto_close=False,
             **kwargs,
@@ -1542,7 +1543,7 @@ class ProtectApiClient(BaseApiClient):
 
         r = await self.request(
             "get",
-            urljoin(self.api_path, path),
+            f"{self.api_path}/{path}",
             auto_close=False,
             timeout=0,
             params=params,


### PR DESCRIPTION
We were doing complex url joins when we were only joining paths we already hard code internally which meant everything had to get parsed into url parts, joined together, and than reassembled