### PR TITLE
fix: typing with version of propcache older than 1.0.0

### DIFF
--- a/src/uiprotect/_compat.py
+++ b/src/uiprotect/_compat.py
@@ -1,8 +1,13 @@
 """Compat for external lib versions."""
 
-try:
-    from propcache.api import cached_property
-except ImportError:
-    from propcache import cached_property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from functools import cached_property
+else:
+    try:
+        from propcache.api import cached_property
+    except ImportError:
+        from propcache import cached_property
 
 __all__ = ("cached_property",)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved import logic for `cached_property` to enhance type checking without losing backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->