### PR TITLE
fix: talkback stream bitrate settings

### DIFF
--- a/src/uiprotect/stream.py
+++ b/src/uiprotect/stream.py
@@ -130,10 +130,6 @@ class TalkbackStream(FfmpegCommand):
         if len(input_args) > 0:
             input_args += " "
 
-        bitrate = camera.talkback_settings.bits_per_sample * 1000
-        # 8000 seems to result in best quality without overloading the camera
-        udp_bitrate = bitrate + 8000
-
         # vn = no video
         # acodec = audio codec to encode output in (aac)
         # ac = number of output channels (1)
@@ -143,8 +139,8 @@ class TalkbackStream(FfmpegCommand):
             "-loglevel info -hide_banner "
             f'{input_args}-i "{content_url}" -vn '
             f"-acodec {camera.talkback_settings.type_fmt.value} -ac {camera.talkback_settings.channels} "
-            f"-ar {camera.talkback_settings.sampling_rate} -b:a {bitrate} -map 0:a "
-            f'-f adts "udp://{camera.host}:{camera.talkback_settings.bind_port}?bitrate={udp_bitrate}"'
+            f"-ar {camera.talkback_settings.sampling_rate} -b:a {camera.talkback_settings.sampling_rate} -map 0:a "
+            f'-f adts "udp://{camera.host}:{camera.talkback_settings.bind_port}?bitrate={camera.talkback_settings.sampling_rate}"'
         )
 
         super().__init__(cmd, ffmpeg_path)


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Adjust the ffmpeg command for the TalkbackStream, specifically the bitrate and sampling rate settings, to correct them to values that give proper audio from the camera speaker.  I only have a couple of G4 Instant cameras to test with, but this change results in almost perfect audio coming from them.

There is still considerable popping in the audio, but at least now it doesn't sound muddled, and it plays at the correct speed.  I'll continue playing with ffmpeg to see if I can get a nice clean stream to one of my cameras and send in another PR to further increase the audio quality if I figure anything else out, but as-is, this PR is a big step in a good direction, it's actually usable now with TTS whereas before it was so fast and muddled you could barely understand what was being said.
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined command construction for audio bitrate and UDP bitrate by directly utilizing the sampling rate from talkback settings.
  
- **Bug Fixes**
	- Removed unnecessary calculations for bitrate, improving efficiency in command string generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->