### PR TITLE
feat: add support for fetching the rtsp url without srtp

### DIFF
--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -273,6 +273,7 @@ class CameraChannel(ProtectBaseObject):
 
     _rtsp_url: str | None = PrivateAttr(None)
     _rtsps_url: str | None = PrivateAttr(None)
+    _rtsps_no_srtp_url: str | None = PrivateAttr(None)
 
     @property
     def rtsp_url(self) -> str | None:
@@ -293,6 +294,16 @@ class CameraChannel(ProtectBaseObject):
             return self._rtsps_url
         self._rtsps_url = f"rtsps://{self._api.connection_host}:{self._api.bootstrap.nvr.ports.rtsps}/{self.rtsp_alias}?enableSrtp"
         return self._rtsps_url
+
+    @property
+    def rtsps_no_srtp_url(self) -> str | None:
+        if not self.is_rtsp_enabled or self.rtsp_alias is None:
+            return None
+
+        if self._rtsps_no_srtp_url is not None:
+            return self._rtsps_no_srtp_url
+        self._rtsps_no_srtp_url = f"rtsps://{self._api.connection_host}:{self._api.bootstrap.nvr.ports.rtsps}/{self.rtsp_alias}"
+        return self._rtsps_no_srtp_url
 
     @property
     def is_package(self) -> bool:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,14 +81,19 @@ async def check_camera(camera: Camera):
 
     for channel in camera.channels:
         if channel.is_rtsp_enabled:
-            assert (
-                channel.rtsp_url
-                == f"rtsp://{camera.api.connection_host}:7447/{channel.rtsp_alias}"
-            )
-            assert (
-                channel.rtsps_url
-                == f"rtsps://{camera.api.connection_host}:7441/{channel.rtsp_alias}?enableSrtp"
-            )
+            for _ in range(2):
+                assert (
+                    channel.rtsp_url
+                    == f"rtsp://{camera.api.connection_host}:7447/{channel.rtsp_alias}"
+                )
+                assert (
+                    channel.rtsps_url
+                    == f"rtsps://{camera.api.connection_host}:7441/{channel.rtsp_alias}?enableSrtp"
+                )
+                assert (
+                    channel.rtsps_no_srtp_url
+                    == f"rtsps://{camera.api.connection_host}:7441/{channel.rtsp_alias}"
+                )
 
     if VideoMode.HIGH_FPS in camera.feature_flags.video_modes:
         assert camera.feature_flags.has_highfps


### PR DESCRIPTION
`go2rtc` doesn't support `srtp` yet and it doesn't need it anyways since we always use tcp with `rtsps`

https://github.com/AlexxIT/go2rtc/?tab=readme-ov-file#source-rtsp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new RTSP streaming URL property (`rtsps_no_srtp_url`) for enhanced streaming capabilities.
	- Added a method to manage privacy zones in camera views, allowing users to enable or disable privacy settings.

- **Bug Fixes**
	- Improved validation of RTSP URLs in testing to ensure correct formatting and reliability.

These changes enhance the functionality and reliability of camera management features for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->