### PR TITLE
feat: add processing for NFC scan events

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -98,6 +98,7 @@ CAMERA_EVENT_ATTR_MAP: dict[EventType, tuple[str, str]] = {
         "last_smart_audio_detect_event_id",
     ),
     EventType.RING: ("last_ring", "last_ring_event_id"),
+    EventType.NFC_CARD_SCANNED: ("last_nfc_card_scanned", "last_nfc_card_scanned_event_id"),
 }
 
 

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -98,7 +98,10 @@ CAMERA_EVENT_ATTR_MAP: dict[EventType, tuple[str, str]] = {
         "last_smart_audio_detect_event_id",
     ),
     EventType.RING: ("last_ring", "last_ring_event_id"),
-    EventType.NFC_CARD_SCANNED: ("last_nfc_card_scanned", "last_nfc_card_scanned_event_id"),
+    EventType.NFC_CARD_SCANNED: (
+        "last_nfc_card_scanned",
+        "last_nfc_card_scanned_event_id",
+    ),
 }
 
 

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -936,6 +936,7 @@ class Camera(ProtectMotionDeviceModel):
     is_probing_for_wifi: bool
     chime_duration: timedelta
     last_ring: datetime | None
+    last_nfc_card_scanned: datetime | None
     is_live_heatmap_enabled: bool
     video_reconfiguration_in_progress: bool
     channels: list[CameraChannel]
@@ -998,6 +999,7 @@ class Camera(ProtectMotionDeviceModel):
 
     # not directly from UniFi
     last_ring_event_id: str | None = None
+    last_nfc_card_scanned_event_id: str | None = None
     last_smart_detect: datetime | None = None
     last_smart_audio_detect: datetime | None = None
     last_smart_detect_event_id: str | None = None
@@ -1018,6 +1020,7 @@ class Camera(ProtectMotionDeviceModel):
     def _get_excluded_changed_fields(cls) -> set[str]:
         return super()._get_excluded_changed_fields() | {
             "last_ring_event_id",
+            "last_nfc_card_scanned_event_id",
             "last_smart_detect",
             "last_smart_audio_detect",
             "last_smart_detect_event_id",
@@ -1140,6 +1143,12 @@ class Camera(ProtectMotionDeviceModel):
         if (last_ring_event_id := self.last_ring_event_id) is None:
             return None
         return self._api.bootstrap.events.get(last_ring_event_id)
+
+    @property
+    def last_nfc_card_scanned_event(self) -> Event | None:
+        if (last_nfc_card_scanned_event_id := self.last_nfc_card_scanned_event_id) is None:
+            return None
+        return self._api.bootstrap.events.get(last_nfc_card_scanned_event_id)
 
     @property
     def last_smart_detect_event(self) -> Event | None:

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -1146,7 +1146,9 @@ class Camera(ProtectMotionDeviceModel):
 
     @property
     def last_nfc_card_scanned_event(self) -> Event | None:
-        if (last_nfc_card_scanned_event_id := self.last_nfc_card_scanned_event_id) is None:
+        if (
+            last_nfc_card_scanned_event_id := self.last_nfc_card_scanned_event_id
+        ) is None:
             return None
         return self._api.bootstrap.events.get(last_nfc_card_scanned_event_id)
 

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -135,9 +135,11 @@ class EventThumbnailAttribute(ProtectBaseObject):
     confidence: int
     val: str
 
+
 class NfcMetadata:
     nfcId: str
     userId: str
+
 
 class EventThumbnailAttributes(ProtectBaseObject):
     color: EventThumbnailAttribute | None = None

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -135,6 +135,9 @@ class EventThumbnailAttribute(ProtectBaseObject):
     confidence: int
     val: str
 
+class NfcMetadata:
+    nfcId: str
+    userId: str
 
 class EventThumbnailAttributes(ProtectBaseObject):
     color: EventThumbnailAttribute | None = None
@@ -195,6 +198,7 @@ class EventMetadata(ProtectBaseObject):
     license_plate: LicensePlateMetadata | None = None
     # requires 2.11.13+
     detected_thumbnails: list[EventDetectedThumbnail] | None = None
+    nfc: NfcMetadata | None = None
 
     _collapse_keys: ClassVar[SetStr] = {
         "lightId",

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -201,6 +201,7 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     POOR_CONNECTION = "poorConnection"
     STREAM_RECOVERY = "streamRecovery"
     MOTION = "motion"
+    NFC_CARD_SCANNED = "nfcCardScanned"
     RECORDING_DELETED = "recordingDeleted"
     SMART_AUDIO_DETECT = "smartAudioDetect"
     SMART_DETECT = "smartDetectZone"
@@ -274,6 +275,7 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     def device_events() -> list[str]:
         return [
             EventType.MOTION.value,
+            EventType.NFC_CARD_SCANNED.value,
             EventType.RING.value,
             EventType.SMART_DETECT.value,
             EventType.SMART_AUDIO_DETECT.value,

--- a/tests/sample_data/sample_raw_events.json
+++ b/tests/sample_data/sample_raw_events.json
@@ -29985,5 +29985,30 @@
         "heatmap": "e-df90543f94ff894427b79827",
         "modelKey": "event",
         "timestamp": null
+    },
+    {
+        "id": "6730b5af01029603e4453bdb",
+        "modelKey": "event",
+        "type": "nfcCardScanned",
+        "start": 1731245487257,
+        "end": 1731245487257,
+        "score": 0,
+        "smartDetectTypes": [],
+        "smartDetectEvents": [],
+        "camera": "1c9a2db4df6efda47a6749be",
+        "partition": null,
+        "user": null,
+        "metadata": {
+            "nfc": {
+                "nfcId": "64B2A621",
+                "userId": "672b573764f79603e400031d"
+            },
+            "ramDescription": "",
+            "ramClassifications": []
+        },
+        "thumbnail": "e-6730b5af01029603e4003bdb",
+        "heatmap": "e-6730b5af01029603e4003bdb",
+        "timestamp": 1731245487257,
+        "category": null
     }
 ]

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -329,12 +329,9 @@ async def test_ws_event_nfc_card_scanned(
         "partition": None,
         "user": None,
         "metadata": {
-            "nfc": {
-                "nfcId": expected_nfcId,
-                "userId": expected_userId
-            },
+            "nfc": {"nfcId": expected_nfcId, "userId": expected_userId},
             "ramDescription": "",
-            "ramClassifications": []
+            "ramClassifications": [],
         },
         "thumbnail": f"e-{expected_event_id}",
         "heatmap": f"e-{expected_event_id}",
@@ -354,8 +351,8 @@ async def test_ws_event_nfc_card_scanned(
 
     assert event.id == expected_event_id
     assert event.type == EventType.NFC_CARD_SCANNED
-    assert event.metadata.nfc.get('nfcId') == expected_nfcId
-    assert event.metadata.nfc.get('userId') == expected_userId
+    assert event.metadata.nfc.get("nfcId") == expected_nfcId
+    assert event.metadata.nfc.get("userId") == expected_userId
     assert event.id == expected_event_id
     assert event.thumbnail_id == f"e-{expected_event_id}"
     assert event.heatmap_id == f"e-{expected_event_id}"

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -295,6 +295,78 @@ async def test_ws_event_motion(
 
 @pytest.mark.asyncio()
 @patch("uiprotect.api.datetime", MockDatetime)
+async def test_ws_event_nfc_card_scanned(
+    protect_client_no_debug: ProtectApiClient,
+    now,
+    camera,
+    packet: WSPacket,
+):
+    protect_client = protect_client_no_debug
+
+    def get_camera():
+        return protect_client.bootstrap.cameras[camera["id"]]
+
+    camera_before = get_camera().copy()
+
+    expected_updated_id = "0441ecc6-f0fa-4b03-b071-7987c143138a"
+    expected_event_id = "6730b5af01029603e4003bdb"
+    expected_nfcId = "66B2A649"
+    expected_userId = "672b570000f79603e400049d"
+
+    action_frame: WSJSONPacketFrame = packet.action_frame  # type: ignore[assignment]
+    action_frame.data["newUpdateId"] = expected_updated_id
+
+    data_frame: WSJSONPacketFrame = packet.data_frame  # type: ignore[assignment]
+    data_frame.data = {
+        "id": expected_event_id,
+        "type": "nfcCardScanned",
+        "start": to_js_time(now - timedelta(seconds=30)),
+        "end": to_js_time(now),
+        "score": 0,
+        "smartDetectTypes": [],
+        "smartDetectEvents": [],
+        "camera": camera["id"],
+        "partition": None,
+        "user": None,
+        "metadata": {
+            "nfc": {
+                "nfcId": expected_nfcId,
+                "userId": expected_userId
+            },
+            "ramDescription": "",
+            "ramClassifications": []
+        },
+        "thumbnail": f"e-{expected_event_id}",
+        "heatmap": f"e-{expected_event_id}",
+        "modelKey": "event",
+    }
+
+    msg = MagicMock()
+    msg.data = packet.pack_frames()
+
+    protect_client._process_ws_message(msg)
+
+    camera = get_camera()
+
+    event = camera.last_nfc_card_scanned_event
+    camera_before.last_nfc_card_scanned_event_id = None
+    camera.last_nfc_card_scanned_event_id = None
+
+    assert event.id == expected_event_id
+    assert event.type == EventType.NFC_CARD_SCANNED
+    assert event.metadata.nfc.get('nfcId') == expected_nfcId
+    assert event.metadata.nfc.get('userId') == expected_userId
+    assert event.id == expected_event_id
+    assert event.thumbnail_id == f"e-{expected_event_id}"
+    assert event.heatmap_id == f"e-{expected_event_id}"
+    assert event.start == (now - timedelta(seconds=30))
+
+    for channel in camera.channels:
+        assert channel._api is not None
+
+
+@pytest.mark.asyncio()
+@patch("uiprotect.api.datetime", MockDatetime)
 async def test_ws_event_smart(
     protect_client_no_debug: ProtectApiClient,
     now,


### PR DESCRIPTION
### Description of change

Fixes #263

Some tests fail need help fixing them

`FAILED tests/data/test_common.py::test_camera - AssertionError: assert {'anonymousDe...': False, ...} == {'anonymousDe...': False, ...}
FAILED tests/data/test_common.py::test_events - pydantic.v1.error_wrappers.ValidationError: 1 validation error for Event
FAILED tests/data/test_common.py::test_bootstrap - AssertionError: assert {'anonymousDe...': False, ...} == {'anonymousDe...': False, ...}
FAILED tests/test_api.py::test_get_events_raw_default - AssertionError: assert 1375 == 1374
FAILED tests/test_api.py::test_get_events - pydantic.v1.error_wrappers.ValidationError: 1 validation error for Event
FAILED tests/test_api.py::test_get_camera_video - FileNotFoundError: [Errno 2] No such file or directory: 'ffprobe'
`

### Pull-Request Checklist
- [x] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for NFC card scanning events, enhancing camera event handling.
	- Added properties to track the last NFC card scanned and its event ID in the Camera class.
	- Implemented a new class for NFC metadata, allowing for detailed event tracking.

- **Tests**
	- Added a new asynchronous test to validate NFC card scanned event handling in WebSocket communication. 

These updates improve the system's capability to manage and track NFC-related events effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->