### PR TITLE
feat: add processing for NFC scan events #265

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -98,6 +98,10 @@ CAMERA_EVENT_ATTR_MAP: dict[EventType, tuple[str, str]] = {
         "last_smart_audio_detect_event_id",
     ),
     EventType.RING: ("last_ring", "last_ring_event_id"),
+    EventType.NFC_CARD_SCANNED: (
+        "last_nfc_card_scanned",
+        "last_nfc_card_scanned_event_id",
+    ),
 }
 
 

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -1156,7 +1156,9 @@ class Camera(ProtectMotionDeviceModel):
 
     @property
     def last_nfc_card_scanned_event(self) -> Event | None:
-        if (last_nfc_card_scanned_event_id := self.last_nfc_card_scanned_event_id) is None:
+        if (
+            last_nfc_card_scanned_event_id := self.last_nfc_card_scanned_event_id
+        ) is None:
             return None
         return self._api.bootstrap.events.get(last_nfc_card_scanned_event_id)
 

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -998,6 +998,8 @@ class Camera(ProtectMotionDeviceModel):
 
     # not directly from UniFi
     last_ring_event_id: str | None = None
+    last_nfc_card_scanned_event_id: str | None = None
+    last_nfc_card_scanned: datetime | None = None
     last_smart_detect: datetime | None = None
     last_smart_audio_detect: datetime | None = None
     last_smart_detect_event_id: str | None = None
@@ -1018,6 +1020,8 @@ class Camera(ProtectMotionDeviceModel):
     def _get_excluded_changed_fields(cls) -> set[str]:
         return super()._get_excluded_changed_fields() | {
             "last_ring_event_id",
+            "last_nfc_card_scanned",
+            "last_nfc_card_scanned_event_id",
             "last_smart_detect",
             "last_smart_audio_detect",
             "last_smart_detect_event_id",
@@ -1087,6 +1091,8 @@ class Camera(ProtectMotionDeviceModel):
             data,
             (
                 "lastRingEventId",
+                "lastNfcCardScanned",
+                "lastNfcCardScannedEventId",
                 "lastSmartDetect",
                 "lastSmartAudioDetect",
                 "lastSmartDetectEventId",
@@ -1147,6 +1153,12 @@ class Camera(ProtectMotionDeviceModel):
         if (last_smart_detect_event_id := self.last_smart_detect_event_id) is None:
             return None
         return self._api.bootstrap.events.get(last_smart_detect_event_id)
+
+    @property
+    def last_nfc_card_scanned_event(self) -> Event | None:
+        if (last_nfc_card_scanned_event_id := self.last_nfc_card_scanned_event_id) is None:
+            return None
+        return self._api.bootstrap.events.get(last_nfc_card_scanned_event_id)
 
     @property
     def hdr_mode_display(self) -> Literal["auto", "off", "always"]:

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -10,13 +10,14 @@ from datetime import datetime, timedelta, tzinfo
 from functools import cache
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional
 from uuid import UUID
 
 import aiofiles
 import orjson
 from aiofiles import os as aos
 from convertertools import pop_dict_set_if_none, pop_dict_tuple
+from pydantic.v1 import BaseModel
 from pydantic.v1.fields import PrivateAttr
 
 from ..exceptions import BadRequest, NotAuthorized
@@ -136,7 +137,7 @@ class EventThumbnailAttribute(ProtectBaseObject):
     val: str
 
 
-class NfcMetadata:
+class NfcMetadata(BaseModel):
     nfcId: str
     userId: str
 

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -135,9 +135,11 @@ class EventThumbnailAttribute(ProtectBaseObject):
     confidence: int
     val: str
 
+
 class NfcMetadata:
     nfcId: str
     userId: str
+
 
 class EventThumbnailAttributes(ProtectBaseObject):
     color: EventThumbnailAttribute | None = None

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -17,7 +17,6 @@ import aiofiles
 import orjson
 from aiofiles import os as aos
 from convertertools import pop_dict_set_if_none, pop_dict_tuple
-from pydantic.v1 import BaseModel
 from pydantic.v1.fields import PrivateAttr
 
 from ..exceptions import BadRequest, NotAuthorized

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -135,6 +135,9 @@ class EventThumbnailAttribute(ProtectBaseObject):
     confidence: int
     val: str
 
+class NfcMetadata:
+    nfcId: str
+    userId: str
 
 class EventThumbnailAttributes(ProtectBaseObject):
     color: EventThumbnailAttribute | None = None
@@ -195,6 +198,8 @@ class EventMetadata(ProtectBaseObject):
     license_plate: LicensePlateMetadata | None = None
     # requires 2.11.13+
     detected_thumbnails: list[EventDetectedThumbnail] | None = None
+    # requires 5.1.34+
+    nfc: NfcMetadata | None = None
 
     _collapse_keys: ClassVar[SetStr] = {
         "lightId",

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -137,9 +137,18 @@ class EventThumbnailAttribute(ProtectBaseObject):
     val: str
 
 
-class NfcMetadata(BaseModel):
-    nfcId: str
-    userId: str
+class NfcMetadata(ProtectBaseObject):
+    nfc_id: str
+    user_id: str
+
+    @classmethod
+    @cache
+    def _get_unifi_remaps(cls) -> dict[str, str]:
+        return {
+            **super()._get_unifi_remaps(),
+            "nfcId": "nfc_id",
+            "userId": "user_id",
+        }
 
 
 class EventThumbnailAttributes(ProtectBaseObject):

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -201,6 +201,7 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     POOR_CONNECTION = "poorConnection"
     STREAM_RECOVERY = "streamRecovery"
     MOTION = "motion"
+    NFC_CARD_SCANNED = "nfcCardScanned"
     RECORDING_DELETED = "recordingDeleted"
     SMART_AUDIO_DETECT = "smartAudioDetect"
     SMART_DETECT = "smartDetectZone"
@@ -274,6 +275,7 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     def device_events() -> list[str]:
         return [
             EventType.MOTION.value,
+            EventType.NFC_CARD_SCANNED.value,
             EventType.RING.value,
             EventType.SMART_DETECT.value,
             EventType.SMART_AUDIO_DETECT.value,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -878,7 +878,6 @@ def compare_objs(obj_type, expected, actual):
             if "clockBestWall" not in exp_thumb:
                 del act_thumbnails[index]["clockBestWall"]
         assert exp_thumbnails == act_thumbnails
-
         expected_keys = (expected.get("metadata") or {}).keys()
         actual_keys = (actual.get("metadata") or {}).keys()
         # delete all extra metadata keys, many of which are not modeled

--- a/tests/sample_data/sample_constants.json
+++ b/tests/sample_data/sample_constants.json
@@ -7,7 +7,7 @@
     "last_update_id": "ebf25bac-d5a1-4f1d-a0ee-74c15981eb70",
     "user_id": "4c5f03a8c8bd48ad8e066285",
     "counts": {
-        "camera": 11,
+        "camera": 12,
         "user": 7,
         "group": 2,
         "liveview": 5,
@@ -21,7 +21,7 @@
         "schedule": 0
     },
     "time": "2022-01-24T20:23:32.433278+00:00",
-    "event_count": 1374,
+    "event_count": 1375,
     "camera_thumbnail": "e-90f051ebf085214d331644a5",
     "camera_heatmap": "e-90f051ebf085214d331644a5",
     "camera_video_length": 23,

--- a/tests/sample_data/sample_raw_events.json
+++ b/tests/sample_data/sample_raw_events.json
@@ -29985,5 +29985,30 @@
         "heatmap": "e-df90543f94ff894427b79827",
         "modelKey": "event",
         "timestamp": null
+    },
+    {
+        "id": "6730b5af01029603e4453bdb",
+        "modelKey": "event",
+        "type": "nfcCardScanned",
+        "start": 1731245487257,
+        "end": 1731245487257,
+        "score": 0,
+        "smartDetectTypes": [],
+        "smartDetectEvents": [],
+        "camera": "1c9a2db4df6efda47a3509be",
+        "partition": null,
+        "user": null,
+        "metadata": {
+            "nfc": {
+                "nfcId": "64B2A621",
+                "userId": "672b573764f79603e400031d"
+            },
+            "ramDescription": "",
+            "ramClassifications": []
+        },
+        "thumbnail": "e-6730b5af01029603e4003bdb",
+        "heatmap": "e-6730b5af01029603e4003bdb",
+        "timestamp": 1731245487257,
+        "category": null
     }
 ]

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -355,6 +355,8 @@ async def test_ws_event_nfc_card_scanned(
     assert event.thumbnail_id == f"e-{expected_event_id}"
     assert event.heatmap_id == f"e-{expected_event_id}"
     assert event.start == (now - timedelta(seconds=30))
+    assert event.end == now
+    assert camera.last_nfc_card_scanned == event.start
 
     for channel in camera.channels:
         assert channel._api is not None

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -328,12 +328,9 @@ async def test_ws_event_nfc_card_scanned(
         "smartDetectEvents": [],
         "camera": camera["id"],
         "metadata": {
-            "nfc": {
-                "nfcId": expected_nfc_id,
-                "userId": expected_user_id
-            },
+            "nfc": {"nfcId": expected_nfc_id, "userId": expected_user_id},
             "ramDescription": "",
-            "ramClassifications": []
+            "ramClassifications": [],
         },
         "thumbnail": f"e-{expected_event_id}",
         "heatmap": f"e-{expected_event_id}",

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -350,8 +350,8 @@ async def test_ws_event_nfc_card_scanned(
     assert camera.dict_with_excludes() == camera_before.dict_with_excludes()
     assert event.id == expected_event_id
     assert event.type == EventType.NFC_CARD_SCANNED
-    assert event.metadata.nfc.get("nfcId") == expected_nfc_id
-    assert event.metadata.nfc.get("userId") == expected_user_id
+    assert event.metadata.nfc.nfc_id == expected_nfc_id
+    assert event.metadata.nfc.user_id == expected_user_id
     assert event.thumbnail_id == f"e-{expected_event_id}"
     assert event.heatmap_id == f"e-{expected_event_id}"
     assert event.start == (now - timedelta(seconds=30))


### PR DESCRIPTION
### Description of change

Fixes  #263 

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced support for NFC card scanning events, enhancing camera event processing capabilities.
  - Added new properties to the Camera class to track NFC card scan events.
  - New `NfcMetadata` class added to encapsulate NFC-related information.

- **Bug Fixes**
  - Updated event handling to ensure accurate processing of NFC card scanned events.

- **Tests**
  - Added new asynchronous test for validating NFC card scanned event handling in WebSocket communication.
  - Enhanced test fixtures to improve coverage and support for new features.

- **Documentation**
  - Updated comments and docstrings to reflect new attributes and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->