### PR TITLE
fix: handle IndexError selecting value "below 1 Lux" for icr_custom_value

### DIFF
--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -94,6 +94,7 @@ LUX_MAPPING_VALUES = [
     5,
     3,
     1,
+    0
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -83,19 +83,7 @@ if TYPE_CHECKING:
     from .nvr import Event, Liveview
 
 PRIVACY_ZONE_NAME = "pyufp_privacy_zone"
-LUX_MAPPING_VALUES = [
-    30,
-    25,
-    20,
-    15,
-    12,
-    10,
-    7,
-    5,
-    3,
-    1,
-    0
-]
+LUX_MAPPING_VALUES = [30, 25, 20, 15, 12, 10, 7, 5, 3, 1, 0]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -1111,7 +1111,9 @@ async def test_camera_set_icr_custom_lux(
         pytest.skip("No camera_obj obj found")
 
     camera_obj.feature_flags.has_led_ir = True
-    if value == 0: #without this there is no change that gets send if the test value is 0
+    if (
+        value == 0
+    ):  # without this there is no change that gets send if the test value is 0
         camera_obj.isp_settings.icr_custom_value = 1
     else:
         camera_obj.isp_settings.icr_custom_value = 0

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -1088,6 +1088,7 @@ async def test_camera_disable_co(camera_obj: Camera | None, status: bool):
 @pytest.mark.parametrize(
     ("value", "lux"),
     [
+        (0, 0),
         (1, 1),
         (2, 3),
         (3, 5),
@@ -1110,7 +1111,10 @@ async def test_camera_set_icr_custom_lux(
         pytest.skip("No camera_obj obj found")
 
     camera_obj.feature_flags.has_led_ir = True
-    camera_obj.isp_settings.icr_custom_value = 0
+    if value == 0: #without this there is no change that gets send if the test value is 0
+        camera_obj.isp_settings.icr_custom_value = 1
+    else:
+        camera_obj.isp_settings.icr_custom_value = 0
 
     camera_obj.api.api_request.reset_mock()
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #282

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `LUX_MAPPING_VALUES` to include an additional value, enhancing light sensitivity calculations.
  
- **Bug Fixes**
	- Improved behavior of the `set_icr_custom_lux` method to ensure proper API requests when the input value is `0`.

- **Tests**
	- Added a new test function to validate the `set_icr_custom_lux` method under various conditions, enhancing testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->