### PR TITLE
Allow get snapshot with liveonly permissions

### DIFF
--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -2013,15 +2013,16 @@ class Camera(ProtectMotionDeviceModel):
 
         Datetime of screenshot is approximate. It may be +/- a few seconds.
         """
+        # Use READ_LIVE if dt is None, otherwise READ_MEDIA
         permission = (
-        PermissionNode.READ_LIVE if datetime is None else PermissionNode.READ_MEDIA
+            PermissionNode.READ_LIVE if dt is None else PermissionNode.READ_MEDIA
         )
         if not self._api.bootstrap.auth_user.can(
             ModelType.CAMERA,
             permission,
             self,
         ):
-            action = "read live" if datetime is None else "read media"
+            action = "read live" if dt is None else "read media"
             raise NotAuthorized(
                 f"Do not have permission to {action} for camera: {self.id}"
             )
@@ -2045,13 +2046,18 @@ class Camera(ProtectMotionDeviceModel):
         if not self.feature_flags.has_package_camera:
             raise BadRequest("Device does not have package camera")
 
+        # Use READ_LIVE if dt is None, otherwise READ_MEDIA
+        permission = (
+            PermissionNode.READ_LIVE if dt is None else PermissionNode.READ_MEDIA
+        )
         if not self._api.bootstrap.auth_user.can(
             ModelType.CAMERA,
-            PermissionNode.READ_MEDIA,
+            permission,
             self,
         ):
+            action = "read live" if dt is None else "read media"
             raise NotAuthorized(
-                f"Do not have permission to read media for camera: {self.id}",
+                f"Do not have permission to {action} for camera: {self.id}"
             )
 
         if height is None and width is None and self.package_camera_channel is not None:

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -2013,13 +2013,17 @@ class Camera(ProtectMotionDeviceModel):
 
         Datetime of screenshot is approximate. It may be +/- a few seconds.
         """
+        permission = (
+        PermissionNode.READ_LIVE if datetime is None else PermissionNode.READ_MEDIA
+        )
         if not self._api.bootstrap.auth_user.can(
             ModelType.CAMERA,
-            PermissionNode.READ_MEDIA,
+            permission,
             self,
         ):
+            action = "read live" if datetime is None else "read media"
             raise NotAuthorized(
-                f"Do not have permission to read media for camera: {self.id}",
+                f"Do not have permission to {action} for camera: {self.id}"
             )
 
         if height is None and width is None and self.high_camera_channel is not None:


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

### Description of Change

Currently, users with `view live` permissions in Home Assistant encounter the following error when attempting to access camera snapshots:

```
uiprotect.exceptions.NotAuthorized: Do not have permission to read media for camera
```

This change addresses the issue by ensuring that the READ_LIVE permission is used when dt is None, allowing users with live view permissions to retrieve snapshots as intended. This fix is applied to both get_snapshot and get_package_snapshot methods for consistency.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
