### PR TITLE
fix: import of Self for Python 3.10

### DIFF
--- a/src/uiprotect/data/user.py
+++ b/src/uiprotect/data/user.py
@@ -13,7 +13,7 @@ from pydantic.v1.fields import PrivateAttr
 from .base import ProtectBaseObject, ProtectModel, ProtectModelWithId
 from .types import ModelType, PermissionNode
 
-if sys.version_info > (3, 10):
+if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self


### PR DESCRIPTION
This should be 3.11+ for `typing`

We could probably drop 3.10 support as well since HA doesn't use it and I'm not sure anyone else cares

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of permissions for improved robustness and consistency.
	- Updated compatibility for Python 3.11 and later.
  
- **Bug Fixes**
	- Improved error handling for invalid permission formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->