### PR TITLE
fix: treat no access to keyrings/users as empty

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import http
 import logging
 import re
 import sys
@@ -700,7 +701,10 @@ class BaseApiClient:
         _LOGGER.debug("Websocket state changed: %s", state)
 
 
-ALLOWED_FAILURE_CODES_USERS_KEYRINGS = {403, 404}
+ALLOWED_FAILURE_CODES_USERS_KEYRINGS = {
+    http.HTTPStatus.UNAUTHORIZED.value,
+    http.HTTPStatus.NOT_FOUND.value,
+}
 
 
 class ProtectApiClient(BaseApiClient):

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -702,7 +702,7 @@ class BaseApiClient:
 
 
 ALLOWED_FAILURE_CODES_USERS_KEYRINGS = {
-    http.HTTPStatus.UNAUTHORIZED.value,
+    http.HTTPStatus.FORBIDDEN.value,
     http.HTTPStatus.NOT_FOUND.value,
 }
 

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -700,6 +700,9 @@ class BaseApiClient:
         _LOGGER.debug("Websocket state changed: %s", state)
 
 
+ALLOWED_FAILURE_CODES_USERS_KEYRINGS = {403, 404}
+
+
 class ProtectApiClient(BaseApiClient):
     """
     Main UFP API Client
@@ -832,14 +835,14 @@ class ProtectApiClient(BaseApiClient):
                 try:
                     keyrings = await self.api_request_list("keyrings")
                 except ClientResponseError as err:
-                    if err.status != (403, 404):
+                    if err.status not in ALLOWED_FAILURE_CODES_USERS_KEYRINGS:
                         raise
                     _LOGGER.debug("No access to keyrings %s, skipping", err.status)
                     keyrings = []
                 try:
                     ulp_users = await self.api_request_list("ulp-users")
                 except ClientResponseError as err:
-                    if err.status != (403, 404):
+                    if err.status not in ALLOWED_FAILURE_CODES_USERS_KEYRINGS:
                         raise
                     _LOGGER.debug("No access to ulp-users %s, skipping", err.status)
                     ulp_users = []

--- a/src/uiprotect/data/user.py
+++ b/src/uiprotect/data/user.py
@@ -252,6 +252,9 @@ class UlpUserKeyringBase(Generic[T]):
     def __init__(self) -> None:
         self._id_to_item: dict[str, T] = {}
 
+    def __len__(self) -> int:
+        return len(self._id_to_item)
+
     @classmethod
     def from_list(cls, items: list[T]) -> Self:
         instance = cls()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,9 +7,10 @@ from datetime import datetime, timedelta
 from io import BytesIO
 from ipaddress import IPv4Address
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from aiohttp import ClientResponseError
 from PIL import Image
 
 from tests.conftest import (
@@ -327,55 +328,117 @@ async def test_force_update_with_nfc_fingerprint_version(
     assert protect_client.bootstrap
     original_bootstrap = protect_client.bootstrap
     protect_client._bootstrap = None
-    with patch(
-        "uiprotect.api.ProtectApiClient.get_bootstrap",
-        AsyncMock(
+    with (
+        patch(
+            "uiprotect.api.ProtectApiClient.get_bootstrap",
             return_value=AsyncMock(
                 nvr=AsyncMock(version=NFC_FINGERPRINT_SUPPORT_VERSION)
-            )
-        ),
-    ) as get_bootstrap_mock:
-        with patch(
-            "uiprotect.api.ProtectApiClient.api_request_list",
-            AsyncMock(
-                side_effect=lambda endpoint: {
-                    "keyrings": [
-                        {
-                            "deviceType": "camera",
-                            "deviceId": "new_device_id_1",
-                            "registryType": "fingerprint",
-                            "registryId": "new_registry_id_1",
-                            "lastActivity": 1733432893331,
-                            "metadata": {},
-                            "ulpUser": "new_ulp_user_id_1",
-                            "id": "new_keyring_id_1",
-                            "modelKey": "keyring",
-                        }
-                    ],
-                    "ulp-users": [
-                        {
-                            "ulpId": "new_ulp_id_1",
-                            "firstName": "localadmin",
-                            "lastName": "",
-                            "fullName": "localadmin",
-                            "avatar": "",
-                            "status": "ACTIVE",
-                            "id": "new_ulp_user_id_1",
-                            "modelKey": "ulpUser",
-                        }
-                    ],
-                }.get(endpoint, [])
             ),
-        ) as api_request_list_mock:
-            await protect_client.update()
-            assert get_bootstrap_mock.called
-            assert api_request_list_mock.called
-            api_request_list_mock.assert_any_call("keyrings")
-            api_request_list_mock.assert_any_call("ulp-users")
-            assert api_request_list_mock.call_count == 2
+        ) as get_bootstrap_mock,
+        patch(
+            "uiprotect.api.ProtectApiClient.api_request_list",
+            side_effect=lambda endpoint: {
+                "keyrings": [
+                    {
+                        "deviceType": "camera",
+                        "deviceId": "new_device_id_1",
+                        "registryType": "fingerprint",
+                        "registryId": "new_registry_id_1",
+                        "lastActivity": 1733432893331,
+                        "metadata": {},
+                        "ulpUser": "new_ulp_user_id_1",
+                        "id": "new_keyring_id_1",
+                        "modelKey": "keyring",
+                    }
+                ],
+                "ulp-users": [
+                    {
+                        "ulpId": "new_ulp_id_1",
+                        "firstName": "localadmin",
+                        "lastName": "",
+                        "fullName": "localadmin",
+                        "avatar": "",
+                        "status": "ACTIVE",
+                        "id": "new_ulp_user_id_1",
+                        "modelKey": "ulpUser",
+                    }
+                ],
+            }.get(endpoint, []),
+        ) as api_request_list_mock,
+    ):
+        await protect_client.update()
+        assert get_bootstrap_mock.called
+        assert api_request_list_mock.called
+        api_request_list_mock.assert_any_call("keyrings")
+        api_request_list_mock.assert_any_call("ulp-users")
+        assert api_request_list_mock.call_count == 2
 
-        assert protect_client.bootstrap
-        assert original_bootstrap != protect_client.bootstrap
+    assert protect_client.bootstrap
+    assert original_bootstrap != protect_client.bootstrap
+    assert len(protect_client.bootstrap.keyrings)
+    assert len(protect_client.bootstrap.ulp_users)
+
+
+@pytest.mark.asyncio()
+async def test_force_update_no_user_keyring_access(
+    protect_client: ProtectApiClient,
+):
+    protect_client._bootstrap = None
+
+    await protect_client.update()
+
+    assert protect_client.bootstrap
+    original_bootstrap = protect_client.bootstrap
+    protect_client._bootstrap = None
+    with (
+        patch(
+            "uiprotect.api.ProtectApiClient.get_bootstrap",
+            return_value=AsyncMock(
+                nvr=AsyncMock(version=NFC_FINGERPRINT_SUPPORT_VERSION)
+            ),
+        ) as get_bootstrap_mock,
+        patch(
+            "uiprotect.api.ProtectApiClient.api_request_list",
+            side_effect=ClientResponseError(Mock(), (), code=403),
+        ) as api_request_list_mock,
+    ):
+        await protect_client.update()
+        assert get_bootstrap_mock.called
+        assert api_request_list_mock.called
+        api_request_list_mock.assert_any_call("keyrings")
+        api_request_list_mock.assert_any_call("ulp-users")
+        assert api_request_list_mock.call_count == 2
+
+    assert protect_client.bootstrap
+    assert original_bootstrap != protect_client.bootstrap
+    assert not len(protect_client.bootstrap.keyrings)
+    assert not len(protect_client.bootstrap.ulp_users)
+
+
+@pytest.mark.asyncio()
+async def test_force_update_user_keyring_internal_error(
+    protect_client: ProtectApiClient,
+):
+    protect_client._bootstrap = None
+
+    await protect_client.update()
+
+    assert protect_client.bootstrap
+    protect_client._bootstrap = None
+    with (
+        pytest.raises(ClientResponseError),
+        patch(
+            "uiprotect.api.ProtectApiClient.get_bootstrap",
+            return_value=AsyncMock(
+                nvr=AsyncMock(version=NFC_FINGERPRINT_SUPPORT_VERSION)
+            ),
+        ),
+        patch(
+            "uiprotect.api.ProtectApiClient.api_request_list",
+            side_effect=ClientResponseError(Mock(), (), code=500),
+        ),
+    ):
+        await protect_client.update()
 
 
 @pytest.mark.asyncio()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -379,9 +379,10 @@ async def test_force_update_with_nfc_fingerprint_version(
     assert len(protect_client.bootstrap.ulp_users)
 
 
+@pytest.mark.parametrize("status_code", [404, 403])
 @pytest.mark.asyncio()
 async def test_force_update_no_user_keyring_access(
-    protect_client: ProtectApiClient,
+    protect_client: ProtectApiClient, status_code: int
 ):
     protect_client._bootstrap = None
 
@@ -399,7 +400,7 @@ async def test_force_update_no_user_keyring_access(
         ) as get_bootstrap_mock,
         patch(
             "uiprotect.api.ProtectApiClient.api_request_list",
-            side_effect=ClientResponseError(Mock(), (), code=403),
+            side_effect=ClientResponseError(Mock(), (), code=status_code),
         ) as api_request_list_mock,
     ):
         await protect_client.update()


### PR DESCRIPTION
Fetching keyrings and users fails with a 403 if the user does not have permission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added error handling for API requests related to keyrings and users.
	- Introduced a method to determine the length of keyrings in the user class.

- **Bug Fixes**
	- Enhanced testing for authorization issues and internal errors during keyring access.

- **Tests**
	- Expanded test suite with new scenarios for user keyring access and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->