### PR TITLE
fix: pydantic DeprecationWarning

### DIFF
--- a/src/uiprotect/data/base.py
+++ b/src/uiprotect/data/base.py
@@ -493,7 +493,7 @@ class ProtectBaseObject(BaseModel):
             has_unifi_dicts,
         ) = self._get_protect_model()
         api = self._api
-        _fields = self.model_fields
+        _fields = self.__class__.model_fields
         unifi_obj: ProtectBaseObject | None
         value: Any
 


### PR DESCRIPTION
### Description of change
```
  /.../uiprotect/data/base.py:497: 
      PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated.
      Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    _fields = cls.model_fields
```
https://docs.pydantic.dev/dev/api/base_model/#pydantic.BaseModel.model_fields

Requires #443.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the data updating process to operate directly on class-level attributes, ensuring more consistent and reliable handling of data modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->