### PR TITLE
fix: add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "uiprotect"
 version = "7.5.3"
+license = "MIT"
 description = "Python API for Unifi Protect (Unofficial)"
 authors = ["UI Protect Maintainers <ui@koston.org>"]
 readme = "README.md"
@@ -16,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: MIT License"
 ]
 packages = [
     { include = "uiprotect", from = "src" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the license declaration to clearly specify the MIT license.
  - Removed a redundant licensing reference for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->