### PR TITLE
chore: migrate isort settings in pyproject.toml to use tool.ruff.lint.isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ select = [
 "conftest.py" = ["D100"]
 "docs/conf.py" = ["D100"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["uiprotect", "tests"]
 
 [tool.mypy]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to align with the latest Ruff tool requirements. No impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->