### PR TITLE
feat(api): add API key handling and configuration updates

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -681,7 +681,7 @@ class BaseApiClient:
 
     async def _load_api_key(self) -> None:
         if self._api_key is None:
-            self._read_api_key_config()
+            await self._read_api_key_config()
 
     async def _read_api_key_config(self) -> None:
         """Read API key from config."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1437,19 +1437,27 @@ async def test_update_api_key_config_invalid_json(monkeypatch, caplog):
         "test",
         verify_ssl=False,
     )
+
     class MockFile:
         async def __aenter__(self):
             return self
+
         async def __aexit__(self, exc_type, exc, tb):
             pass
+
         async def read(self):
             return b"{invalid json"
+
         async def write(self, data):
             pass
+
     with patch("aiofiles.open", return_value=MockFile()):
         caplog.set_level("WARNING")
         await client.update_api_key_in_config("testkey")
-        assert any("Invalid config file, ignoring." in r.message for r in caplog.records)
+        assert any(
+            "Invalid config file, ignoring." in r.message for r in caplog.records
+        )
+
 
 @pytest.mark.asyncio
 async def test_update_api_key_config_file_not_found():
@@ -1464,6 +1472,7 @@ async def test_update_api_key_config_file_not_found():
     mock_file = AsyncMockFile()
 
     call_count = {"count": 0}
+
     def open_side_effect(*args, **kwargs):
         call_count["count"] += 1
         if call_count["count"] == 1:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1545,13 +1545,18 @@ def test_ensure_authenticated_loads_api_key(monkeypatch):
         "test",
         verify_ssl=False,
     )
+
     async def fake_read_api_key_config():
         client._api_key = "loaded-key"
+
     monkeypatch.setattr(client, "_read_api_key_config", fake_read_api_key_config)
     client._api_key = None
+
     async def fake_authenticate():
         pass
+
     monkeypatch.setattr(client, "authenticate", fake_authenticate)
     import asyncio
+
     asyncio.get_event_loop().run_until_complete(client.ensure_authenticated())
     assert client._api_key == "loaded-key"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1534,3 +1534,24 @@ async def test_read_api_key_config_file_not_found_logs_debug(caplog):
         assert any(
             "no config file, not loading API key" in r.message for r in caplog.records
         )
+
+
+@pytest.mark.asyncio
+def test_ensure_authenticated_loads_api_key(monkeypatch):
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "test",
+        "test",
+        verify_ssl=False,
+    )
+    async def fake_read_api_key_config():
+        client._api_key = "loaded-key"
+    monkeypatch.setattr(client, "_read_api_key_config", fake_read_api_key_config)
+    client._api_key = None
+    async def fake_authenticate():
+        pass
+    monkeypatch.setattr(client, "authenticate", fake_authenticate)
+    import asyncio
+    asyncio.get_event_loop().run_until_complete(client.ensure_authenticated())
+    assert client._api_key == "loaded-key"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1367,6 +1367,7 @@ async def test_read_auth_config_no_session():
         result = await client._read_auth_config()
         assert result is None
 
+
 class AsyncMockFile:
     def __init__(self):
         self.content = b""
@@ -1385,6 +1386,7 @@ class AsyncMockFile:
     async def read(self):
         return self.content
 
+
 @pytest.mark.asyncio
 async def test_update_api_key_config(tmp_path):
     client = ProtectApiClient(
@@ -1397,8 +1399,10 @@ async def test_update_api_key_config(tmp_path):
     api_key = "testkey"
     mock_file = AsyncMockFile()
 
-    with patch("aiofiles.open", return_value=mock_file) as mock_open, \
-         patch("aiofiles.os.makedirs", return_value=None) as mock_makedirs:
+    with (
+        patch("aiofiles.open", return_value=mock_file) as mock_open,
+        patch("aiofiles.os.makedirs", return_value=None) as mock_makedirs,
+    ):
         await client.update_api_key_in_config(api_key)
         assert mock_file.written
         config = orjson.loads(mock_file.content)
@@ -1409,7 +1413,6 @@ async def test_update_api_key_config(tmp_path):
 
 @pytest.mark.asyncio
 async def test_load_api_key():
-
     client = ProtectApiClient(
         "127.0.0.1",
         0,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1490,6 +1490,7 @@ async def test_update_api_key_config_file_not_found():
         mock_makedirs.assert_called()
         mock_open.assert_called()
 
+
 @pytest.mark.asyncio
 async def test_read_api_key_config_invalid_json_logs_warning(caplog):
     client = ProtectApiClient(
@@ -1499,18 +1500,23 @@ async def test_read_api_key_config_invalid_json_logs_warning(caplog):
         "test",
         verify_ssl=False,
     )
+
     class MockFile:
         async def __aenter__(self):
             return self
+
         async def __aexit__(self, exc_type, exc, tb):
             pass
+
         async def read(self):
             return b"{invalid json"
+
     with patch("aiofiles.open", return_value=MockFile()):
         caplog.set_level("WARNING", logger="uiprotect.api")
         await client._read_api_key_config()
-        assert any("Invalid config file, ignoring." in r.message for r in caplog.records)
-
+        assert any(
+            "Invalid config file, ignoring." in r.message for r in caplog.records
+        )
 
 
 @pytest.mark.asyncio
@@ -1525,4 +1531,6 @@ async def test_read_api_key_config_file_not_found_logs_debug(caplog):
     with patch("aiofiles.open", side_effect=FileNotFoundError):
         caplog.set_level("DEBUG", logger="uiprotect.api")
         await client._read_api_key_config()
-        assert any("no config file, not loading API key" in r.message for r in caplog.records)
+        assert any(
+            "no config file, not loading API key" in r.message for r in caplog.records
+        )


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
The changes introduce API key management to the BaseApiClient class, enabling persistent storage and retrieval of API keys in a configuration file. New asynchronous methods handle reading and writing the API key, and the authentication flow is updated to load the API key as needed. Corresponding asynchronous tests are added to verify this functionality using mocked file operations.
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for storing and retrieving an API key for authentication, with persistent storage in the configuration.
- **Bug Fixes**
  - Improved authentication flow to handle API key loading and saving alongside session cookies.
- **Tests**
  - Introduced new asynchronous tests to verify API key configuration file handling and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->