### PR TITLE
feat(api): add optional API key to ProtectApiClient initialization

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -163,6 +163,7 @@ class BaseApiClient:
     _port: int
     _username: str
     _password: str
+    _api_key: str | None = None
     _verify_ssl: bool
     _ws_timeout: int
 
@@ -189,6 +190,7 @@ class BaseApiClient:
         port: int,
         username: str,
         password: str,
+        api_key: str | None = None,
         verify_ssl: bool = True,
         session: aiohttp.ClientSession | None = None,
         ws_timeout: int = 30,
@@ -203,6 +205,7 @@ class BaseApiClient:
 
         self._username = username
         self._password = password
+        self._api_key = api_key
         self._verify_ssl = verify_ssl
         self._ws_timeout = ws_timeout
         self._ws_receive_timeout = ws_receive_timeout
@@ -727,6 +730,7 @@ class ProtectApiClient(BaseApiClient):
         port: UFP HTTPS port
         username: UFP username
         password: UFP password
+        api_key: API key for UFP
         verify_ssl: Verify HTTPS certificate (default: `True`)
         session: Optional aiohttp session to use (default: generate one)
         override_connection_host: Use `host` as your `connection_host` for RTSP stream instead of using the one provided by UniFi Protect.
@@ -754,6 +758,7 @@ class ProtectApiClient(BaseApiClient):
         port: int,
         username: str,
         password: str,
+        api_key: str | None = None,
         verify_ssl: bool = True,
         session: aiohttp.ClientSession | None = None,
         ws_timeout: int = 30,
@@ -773,6 +778,7 @@ class ProtectApiClient(BaseApiClient):
             port=port,
             username=username,
             password=password,
+            api_key=api_key,
             verify_ssl=verify_ssl,
             session=session,
             ws_timeout=ws_timeout,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1365,3 +1365,16 @@ async def test_read_auth_config_no_session():
     with patch("aiofiles.open", return_value=AsyncMockOpen(b"{}")):
         result = await client._read_auth_config()
         assert result is None
+
+
+def test_api_key_init():
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="my_key",
+        verify_ssl=False,
+    )
+    assert hasattr(client, "_api_key")
+    assert client._api_key == "my_key"


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Preparation for Using the API Key

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
