### PR TITLE
fix(utils): improve UUID handling in convert_unifi_data function

### DIFF
--- a/src/uiprotect/utils.py
+++ b/src/uiprotect/utils.py
@@ -237,10 +237,13 @@ def convert_unifi_data(value: Any, field: FieldInfo) -> Any:
             # cannot do this check too soon because some types cannot be used in isinstance
             if isinstance(value, type_):
                 return value
-            # handle edge case for improperly formatted UUIDs
-            # 00000000-0000-00 0- 000-000000000000
-            if type_ is UUID and value == _BAD_UUID:
-                return _EMPTY_UUID
+            if type_ is UUID:
+                if value == "" or value is None:
+                    return None
+                # handle edge case for improperly formatted UUIDs
+                # 00000000-0000-00 0- 000-000000000000
+                if value == _BAD_UUID:
+                    return _EMPTY_UUID
             if (type_ is IPv4Address) and value == "":
                 return None
             return type_(value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1092,6 +1092,9 @@ def compare_objs(obj_type, expected, actual):
     for key in OLD_FIELDS.intersection(expected.keys()):
         del expected[key]
 
+    if ("anonymousDeviceId" in expected and expected["anonymousDeviceId"] == ""):
+        expected["anonymousDeviceId"] = None
+
     assert expected == actual
 
 

--- a/tests/sample_data/sample_bootstrap.json
+++ b/tests/sample_data/sample_bootstrap.json
@@ -3544,7 +3544,7 @@
             "lastRing": null,
             "isLiveHeatmapEnabled": false,
             "useGlobal": false,
-            "anonymousDeviceId": "7b4e5226-215f-44d1-bbf4-cdfe64599cdb",
+            "anonymousDeviceId": "",
             "eventStats": {
                 "motion": {
                     "today": 1,


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.

Addresses: https://github.com/home-assistant/core/issues/147265
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
