### PR TITLE
refactor(api):  removes release version retrieval return false for compatibility

### DIFF
--- a/LIVE_DATA_CI.md
+++ b/LIVE_DATA_CI.md
@@ -83,7 +83,6 @@ Next step is to create an "environment" for your workflow to run it with the sec
 1. Go to "Settings -> Environments -> New Environment" and name it your Github username.
 2. Change "Deployment Branches" to "Selected Branches" and add `master`
 3. Under "Environment Secrets" add the following secrets:
-
    - `UFP_ADDRESS`: IP or host name to your UFP instance
    - `UFP_PORT`: Port for your UFP instance
    - `UFP_SSL_VERIFY`: True or False. Whether or not to verify SSL certs for instance

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -82,10 +82,7 @@ TOKEN_COOKIE_MAX_EXP_SECONDS = 60
 DEVICE_UPDATE_INTERVAL = 900
 # retry timeout for thumbnails/heatmaps
 RETRY_TIMEOUT = 10
-PROTECT_APT_URLS = [
-    "https://apt.artifacts.ui.com/dists/stretch/release/binary-arm64/Packages",
-    "https://apt.artifacts.ui.com/dists/bullseye/release/binary-arm64/Packages",
-]
+
 TYPES_BUG_MESSAGE = """There is currently a bug in UniFi Protect that makes `start` / `end` not work if `types` is not provided. This means uiprotect has to iterate over all of the events matching the filters provided to return values.
 
 If your Protect instance has a lot of events, this request will take much longer then expected. It is recommended adding additional filters to speed the request up."""
@@ -1912,17 +1909,6 @@ class ProtectApiClient(BaseApiClient):
             client_exceptions.ClientError,
         ) as err:
             raise NvrError(f"Error packages from {url}: {err}") from err
-
-        return versions
-
-    async def get_release_versions(self) -> set[Version]:
-        """Get all release versions for UniFi Protect"""
-        versions: set[Version] = set()
-        for url in PROTECT_APT_URLS:
-            try:
-                versions |= await self._get_versions_from_api(url)
-            except NvrError:
-                _LOGGER.warning("Failed to retrieve release versions from online.")
 
         return versions
 

--- a/src/uiprotect/cli/__init__.py
+++ b/src/uiprotect/cli/__init__.py
@@ -315,25 +315,6 @@ def decode_ws_msg(
 
 
 @app.command()
-def release_versions(ctx: typer.Context) -> None:
-    """Updates the release version cache on disk."""
-    protect = cast(ProtectApiClient, ctx.obj.protect)
-
-    async def callback() -> set[Version]:
-        versions = await protect.get_release_versions()
-        await protect.close_session()
-        return versions
-
-    _setup_logger()
-
-    versions = run_async(callback())
-    output = orjson.dumps(sorted([str(v) for v in versions]))
-
-    Path(RELEASE_CACHE).write_bytes(output)
-    typer.echo(output.decode("utf-8"))
-
-
-@app.command()
 def create_api_key(
     ctx: typer.Context,
     name: str = typer.Argument(..., help="Name for the API key"),

--- a/src/uiprotect/cli/__init__.py
+++ b/src/uiprotect/cli/__init__.py
@@ -13,9 +13,9 @@ from rich.progress import track
 
 from uiprotect.api import MetaInfo, ProtectApiClient
 
-from ..data import Version, WSPacket
+from ..data import WSPacket
 from ..test_util import SampleDataGenerator
-from ..utils import RELEASE_CACHE, get_local_timezone, run_async
+from ..utils import get_local_timezone, run_async
 from ..utils import profile_ws as profile_ws_job
 from .aiports import app as aiports_app
 from .base import CliContext, OutputFormatEnum

--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -680,5 +680,5 @@ class Bootstrap(ProtectBaseObject):
         _LOGGER.debug("Successfully refresh model: %s %s", model_type, device_id)
 
     async def get_is_prerelease(self) -> bool:
-        """Get if current version of Protect is a prerelease version."""
-        return await self.nvr.get_is_prerelease()
+        """[DEPRECATED] Always returns False. Will be removed after HA 2025.8.0."""
+        return False

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -15,12 +15,11 @@ from uuid import UUID
 
 import aiofiles
 import orjson
-from aiofiles import os as aos
 from convertertools import pop_dict_set_if_none, pop_dict_tuple
 from pydantic.fields import PrivateAttr
 
 from ..exceptions import BadRequest, NotAuthorized
-from ..utils import RELEASE_CACHE, convert_to_datetime
+from ..utils import convert_to_datetime
 from .base import (
     ProtectBaseObject,
     ProtectDeviceModel,
@@ -1217,7 +1216,6 @@ class NVR(ProtectDeviceModel):
         return versions
 
     async def get_is_prerelease(self) -> bool:
-
         """[DEPRECATED] Always returns False. Will be removed after HA 2025.8.0."""
         return False
 

--- a/src/uiprotect/data/nvr.py
+++ b/src/uiprotect/data/nvr.py
@@ -1217,29 +1217,9 @@ class NVR(ProtectDeviceModel):
         return versions
 
     async def get_is_prerelease(self) -> bool:
-        """Get if current version of Protect is a prerelease version."""
-        # only EA versions have `-beta` in versions
-        if self.version.is_prerelease:
-            return True
 
-        # 2.6.14 is an EA version that looks like a release version
-        cache_file_path = self._api.cache_dir / "release_cache.json"
-        versions = await self._read_cache_file(
-            cache_file_path,
-        ) or await self._read_cache_file(RELEASE_CACHE)
-        if versions is None or self.version not in versions:
-            versions = await self._api.get_release_versions()
-            try:
-                _LOGGER.debug("Fetching releases from APT repos...")
-                tmp = self._api.cache_dir / "release_cache.tmp.json"
-                await aos.makedirs(self._api.cache_dir, exist_ok=True)
-                async with aiofiles.open(tmp, "wb") as cache_file:
-                    await cache_file.write(orjson.dumps([str(v) for v in versions]))
-                await aos.rename(tmp, cache_file_path)
-            except Exception:
-                _LOGGER.warning("Failed write cache file.")
-
-        return self.version not in versions
+        """[DEPRECATED] Always returns False. Will be removed after HA 2025.8.0."""
+        return False
 
     async def set_smart_detections(self, value: bool) -> None:
         """Set if smart detections are enabled."""

--- a/src/uiprotect/utils.py
+++ b/src/uiprotect/utils.py
@@ -74,8 +74,6 @@ SNAKE_CASE_MATCH_3 = re.compile("([a-z0-9])([A-Z])")
 
 _LOGGER = logging.getLogger(__name__)
 
-RELEASE_CACHE = Path(__file__).parent / "release_cache.json"
-
 _CREATE_TYPES = {IPv6Address, IPv4Address, UUID, Color, Decimal, Path, Version}
 _BAD_UUID = "00000000-0000-00 0- 000-000000000000"
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -210,6 +210,18 @@ def test_early_bootstrap():
 
 @pytest.mark.asyncio()
 @pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
+async def test_get_is_prerelease_returns_false(protect_client: ProtectApiClient):
+    protect_client._bootstrap = None
+
+    await protect_client.update()
+    
+    assert await protect_client.bootstrap.get_is_prerelease() is False
+    assert await protect_client.bootstrap.nvr.get_is_prerelease() is False
+
+
+
+@pytest.mark.asyncio()
+@pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
 async def test_bootstrap_get_device_from_mac(bootstrap):
     orig_bootstrap = deepcopy(bootstrap)
     mac = bootstrap["cameras"][0]["mac"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -214,10 +214,9 @@ async def test_get_is_prerelease_returns_false(protect_client: ProtectApiClient)
     protect_client._bootstrap = None
 
     await protect_client.update()
-    
+
     assert await protect_client.bootstrap.get_is_prerelease() is False
     assert await protect_client.bootstrap.nvr.get_is_prerelease() is False
-
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The pre-release version check always returns false in order to suppress the EA warning in HA.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the ability to fetch and display release versions from the CLI and API.
  * The `release_versions` command is no longer available in the command-line interface.

* **Deprecations**
  * The methods for checking prerelease status now always return `False` and are marked for future removal.

* **Tests**
  * Added a test to verify that prerelease status checks consistently return `False`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->