### PR TITLE
feat(api): add publicapi RTSPS streams management for cameras with create, get, and delete functionalities

### DIFF
--- a/src/uiprotect/cli/__init__.py
+++ b/src/uiprotect/cli/__init__.py
@@ -61,12 +61,10 @@ OPTION_PASSWORD = typer.Option(
     envvar="UFP_PASSWORD",
 )
 OPTION_API_KEY = typer.Option(
-    ...,
+    None,
     "--api-key",
     "-k",
-    help="UniFi Protect API key",
-    prompt=True,
-    hide_input=True,
+    help="UniFi Protect API key (required for public API operations)",
     envvar="UFP_API_KEY",
 )
 OPTION_ADDRESS = typer.Option(
@@ -149,7 +147,7 @@ def main(
     ctx: typer.Context,
     username: str = OPTION_USERNAME,
     password: str = OPTION_PASSWORD,
-    api_key: str = OPTION_API_KEY,
+    api_key: str | None = OPTION_API_KEY,
     address: str = OPTION_ADDRESS,
     port: int = OPTION_PORT,
     verify: bool = OPTION_VERIFY,

--- a/src/uiprotect/cli/cameras.py
+++ b/src/uiprotect/cli/cameras.py
@@ -572,3 +572,107 @@ def set_lcd_text(
     obj: d.Camera = ctx.obj.device
 
     base.run(ctx, obj.set_lcd_text(text_type, text, reset_at))
+
+
+@app.command()
+def create_rtsps_streams(
+    ctx: typer.Context,
+    qualities: list[str] = typer.Argument(
+        ...,
+        help="List of stream qualities to create (e.g., high medium low)",
+    ),
+) -> None:
+    """
+    Creates RTSPS streams for camera.
+    
+    Available qualities are typically: high, medium, low, ultra.
+    Requires API key authentication and public API access.
+    """
+    base.require_device_id(ctx)
+    obj: d.Camera = ctx.obj.device
+    
+    async def create_streams() -> None:
+        try:
+            result = await obj.create_rtsps_streams(qualities)
+            if result is None:
+                typer.secho("Failed to create RTSPS streams", fg="red")
+                raise typer.Exit(1)
+            
+            if ctx.obj.output_format == base.OutputFormatEnum.JSON:
+                stream_data = {quality: result.get_stream_url(quality) for quality in result.get_available_qualities()}
+                base.json_output(stream_data)
+            else:
+                for quality in result.get_available_qualities():
+                    url = result.get_stream_url(quality)
+                    typer.echo(f"{quality:10}\t{url}")
+        except Exception as e:
+            typer.secho(f"Error creating RTSPS streams: {e}", fg="red")
+            raise typer.Exit(1)
+    
+    base.run(ctx, create_streams())
+
+
+@app.command()
+def get_rtsps_streams(ctx: typer.Context) -> None:
+    """
+    Gets existing RTSPS streams for camera.
+    
+    Requires API key authentication and public API access.
+    """
+    base.require_device_id(ctx)
+    obj: d.Camera = ctx.obj.device
+    
+    async def get_streams() -> None:
+        try:
+            result = await obj.get_rtsps_streams()
+            if result is None:
+                typer.secho("No RTSPS streams found or failed to retrieve", fg="yellow")
+                return
+            
+            if ctx.obj.output_format == base.OutputFormatEnum.JSON:
+                stream_data = {quality: result.get_stream_url(quality) for quality in result.get_available_qualities()}
+                base.json_output(stream_data)
+            else:
+                available_qualities = result.get_available_qualities()
+                if not available_qualities:
+                    typer.echo("No RTSPS streams available")
+                else:
+                    for quality in available_qualities:
+                        url = result.get_stream_url(quality)
+                        typer.echo(f"{quality:10}\t{url}")
+        except Exception as e:
+            typer.secho(f"Error getting RTSPS streams: {e}", fg="red")
+            raise typer.Exit(1)
+    
+    base.run(ctx, get_streams())
+
+
+@app.command()
+def delete_rtsps_streams(
+    ctx: typer.Context,
+    qualities: list[str] = typer.Argument(
+        ...,
+        help="List of stream qualities to delete (e.g., high medium low)",
+    ),
+) -> None:
+    """
+    Deletes RTSPS streams for camera.
+    
+    Requires API key authentication and public API access.
+    """
+    base.require_device_id(ctx)
+    obj: d.Camera = ctx.obj.device
+    
+    async def delete_streams() -> None:
+        try:
+            result = await obj.delete_rtsps_streams(qualities)
+            if result:
+                typer.secho(f"Successfully deleted RTSPS streams: {', '.join(qualities)}", fg="green")
+            else:
+                typer.secho(f"Failed to delete RTSPS streams: {', '.join(qualities)}", fg="red")
+                raise typer.Exit(1)
+        except Exception as e:
+            typer.secho(f"Error deleting RTSPS streams: {e}", fg="red")
+            raise typer.Exit(1)
+    
+    base.run(ctx, delete_streams())

--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -80,6 +80,7 @@ from .types import (
 from .user import User
 
 if TYPE_CHECKING:
+    from ..api import RTSPSStreams
     from .nvr import Event, Liveview
 
 PRIVACY_ZONE_NAME = "pyufp_privacy_zone"
@@ -2100,6 +2101,29 @@ class Camera(ProtectMotionDeviceModel):
         return await self._api.get_public_api_camera_snapshot(
             camera_id=self.id, high_quality=high_quality
         )
+
+    async def create_rtsps_streams(
+        self, qualities: list[str] | str
+    ) -> RTSPSStreams | None:
+        """Creates RTSPS streams for camera using public API."""
+        if self._api._api_key is None:
+            raise NotAuthorized("Cannot create RTSPS streams without an API key.")
+
+        return await self._api.create_camera_rtsps_streams(self.id, qualities)
+
+    async def get_rtsps_streams(self) -> RTSPSStreams | None:
+        """Gets existing RTSPS streams for camera using public API."""
+        if self._api._api_key is None:
+            raise NotAuthorized("Cannot get RTSPS streams without an API key.")
+
+        return await self._api.get_camera_rtsps_streams(self.id)
+
+    async def delete_rtsps_streams(self, qualities: list[str] | str) -> bool:
+        """Deletes RTSPS streams for camera using public API."""
+        if self._api._api_key is None:
+            raise NotAuthorized("Cannot delete RTSPS streams without an API key.")
+
+        return await self._api.delete_camera_rtsps_streams(self.id, qualities)
 
     async def get_package_snapshot(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1723,3 +1723,404 @@ def test_is_api_key_set_false():
         verify_ssl=False,
     )
     assert client.is_api_key_set() is False
+
+
+@pytest.mark.asyncio
+async def test_create_camera_rtsps_streams_with_list_qualities():
+    """Test creating RTSPS streams with a list of qualities."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    mock_response = b'{"high": "rtsps://example.com/high", "medium": "rtsps://example.com/medium"}'
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=mock_response)) as mock_request:
+        result = await client.create_camera_rtsps_streams("camera123", ["high", "medium"])
+        
+        mock_request.assert_called_once_with(
+            public_api=True,
+            url="/v1/cameras/camera123/rtsps-stream",
+            method="POST",
+            json={"qualities": ["high", "medium"]},
+        )
+        
+        assert result is not None
+        assert result.get_stream_url("high") == "rtsps://example.com/high"
+        assert result.get_stream_url("medium") == "rtsps://example.com/medium"
+
+
+@pytest.mark.asyncio
+async def test_create_camera_rtsps_streams_with_string_quality():
+    """Test creating RTSPS streams with a single quality string."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    mock_response = b'{"high": "rtsps://example.com/high"}'
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=mock_response)) as mock_request:
+        result = await client.create_camera_rtsps_streams("camera123", "high")
+        
+        mock_request.assert_called_once_with(
+            public_api=True,
+            url="/v1/cameras/camera123/rtsps-stream",
+            method="POST",
+            json={"qualities": ["high"]},
+        )
+        
+        assert result is not None
+        assert result.get_stream_url("high") == "rtsps://example.com/high"
+
+
+@pytest.mark.asyncio
+async def test_create_camera_rtsps_streams_none_response():
+    """Test creating RTSPS streams with None response."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=None)) as mock_request:
+        result = await client.create_camera_rtsps_streams("camera123", ["high"])
+        
+        mock_request.assert_called_once_with(
+            public_api=True,
+            url="/v1/cameras/camera123/rtsps-stream",
+            method="POST",
+            json={"qualities": ["high"]},
+        )
+        
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_create_camera_rtsps_streams_invalid_json():
+    """Test creating RTSPS streams with invalid JSON response."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=b"invalid json")) as mock_request:
+        result = await client.create_camera_rtsps_streams("camera123", ["high"])
+        
+        mock_request.assert_called_once()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_camera_rtsps_streams():
+    """Test getting existing RTSPS streams."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    mock_response = b'{"high": "rtsps://example.com/high", "medium": "rtsps://example.com/medium"}'
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=mock_response)) as mock_request:
+        result = await client.get_camera_rtsps_streams("camera123")
+        
+        mock_request.assert_called_once_with(
+            public_api=True,
+            url="/v1/cameras/camera123/rtsps-stream",
+            method="GET",
+        )
+        
+        assert result is not None
+        assert result.get_stream_url("high") == "rtsps://example.com/high"
+        assert result.get_stream_url("medium") == "rtsps://example.com/medium"
+        assert set(result.get_available_qualities()) == {"high", "medium"}
+
+
+@pytest.mark.asyncio
+async def test_get_camera_rtsps_streams_none_response():
+    """Test getting RTSPS streams with None response."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=None)) as mock_request:
+        result = await client.get_camera_rtsps_streams("camera123")
+        
+        mock_request.assert_called_once_with(
+            public_api=True,
+            url="/v1/cameras/camera123/rtsps-stream",
+            method="GET",
+        )
+        
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_delete_camera_rtsps_streams_success():
+    """Test deleting RTSPS streams successfully."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=b"")) as mock_request:
+        result = await client.delete_camera_rtsps_streams("camera123", ["high", "medium"])
+        
+        mock_request.assert_called_once_with(
+            public_api=True,
+            url="/v1/cameras/camera123/rtsps-stream",
+            method="DELETE",
+            params=[("qualities", "high"), ("qualities", "medium")],
+        )
+        
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_delete_camera_rtsps_streams_single_quality():
+    """Test deleting RTSPS streams with single quality."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=b"")) as mock_request:
+        result = await client.delete_camera_rtsps_streams("camera123", "high")
+        
+        mock_request.assert_called_once_with(
+            public_api=True,
+            url="/v1/cameras/camera123/rtsps-stream",
+            method="DELETE",
+            params=[("qualities", "high")],
+        )
+        
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_delete_camera_rtsps_streams_failure():
+    """Test deleting RTSPS streams with failure."""
+    client = ProtectApiClient(
+        "127.0.0.1",
+        0,
+        "user",
+        "pass",
+        api_key="test_key",
+        verify_ssl=False,
+    )
+    
+    with patch.object(client, "api_request_raw", new=AsyncMock(return_value=None)) as mock_request:
+        result = await client.delete_camera_rtsps_streams("camera123", ["high"])
+        
+        mock_request.assert_called_once_with(
+            public_api=True,
+            url="/v1/cameras/camera123/rtsps-stream",
+            method="DELETE",
+            params=[("qualities", "high")],
+        )
+        
+        assert result is False
+
+
+def test_rtsps_streams_class():
+    """Test RTSPSStreams class functionality."""
+    from uiprotect.api import RTSPSStreams
+    
+    # Test with multiple qualities
+    streams = RTSPSStreams(
+        high="rtsps://example.com/high",
+        medium="rtsps://example.com/medium",
+        low="rtsps://example.com/low"
+    )
+    
+    assert streams.get_stream_url("high") == "rtsps://example.com/high"
+    assert streams.get_stream_url("medium") == "rtsps://example.com/medium"
+    assert streams.get_stream_url("low") == "rtsps://example.com/low"
+    assert streams.get_stream_url("nonexistent") is None
+    
+    available_qualities = streams.get_available_qualities()
+    assert set(available_qualities) == {"high", "medium", "low"}
+    
+    # Test with single quality
+    single_stream = RTSPSStreams(ultra="rtsps://example.com/ultra")
+    assert single_stream.get_stream_url("ultra") == "rtsps://example.com/ultra"
+    assert set(single_stream.get_available_qualities()) == {"ultra"}
+    
+    # Test with empty streams
+    empty_stream = RTSPSStreams()
+    assert empty_stream.get_stream_url("any") is None
+    assert empty_stream.get_available_qualities() == []
+
+
+@pytest.mark.asyncio
+async def test_camera_create_rtsps_streams():
+    """Test Camera.create_rtsps_streams method."""
+    from uiprotect.api import RTSPSStreams
+    from uiprotect.data import Camera
+    from uiprotect.exceptions import NotAuthorized
+    
+    # Mock camera and API
+    camera = AsyncMock(spec=Camera)
+    camera.id = "test_camera_id"
+    camera._api = AsyncMock()
+    camera._api._api_key = "test_api_key"
+    camera._api.create_camera_rtsps_streams = AsyncMock(
+        return_value=RTSPSStreams(high="rtsps://example.com/high")
+    )
+    
+    # Bind the actual method to the mock
+    from uiprotect.data.devices import Camera
+    camera.create_rtsps_streams = Camera.create_rtsps_streams.__get__(camera, Camera)
+    
+    # Test successful creation
+    result = await camera.create_rtsps_streams(["high"])
+    assert result is not None
+    assert result.get_stream_url("high") == "rtsps://example.com/high"
+    camera._api.create_camera_rtsps_streams.assert_called_once_with("test_camera_id", ["high"])
+
+
+@pytest.mark.asyncio
+async def test_camera_create_rtsps_streams_no_api_key():
+    """Test Camera.create_rtsps_streams method without API key."""
+    from uiprotect.data import Camera
+    from uiprotect.exceptions import NotAuthorized
+    
+    # Mock camera and API without key
+    camera = AsyncMock(spec=Camera)
+    camera.id = "test_camera_id"
+    camera._api = AsyncMock()
+    camera._api._api_key = None
+    
+    # Bind the actual method to the mock
+    from uiprotect.data.devices import Camera
+    camera.create_rtsps_streams = Camera.create_rtsps_streams.__get__(camera, Camera)
+    
+    # Test that it raises NotAuthorized
+    with pytest.raises(NotAuthorized, match="Cannot create RTSPS streams without an API key"):
+        await camera.create_rtsps_streams(["high"])
+
+
+@pytest.mark.asyncio
+async def test_camera_get_rtsps_streams():
+    """Test Camera.get_rtsps_streams method."""
+    from uiprotect.api import RTSPSStreams
+    from uiprotect.data import Camera
+    
+    # Mock camera and API
+    camera = AsyncMock(spec=Camera)
+    camera.id = "test_camera_id"
+    camera._api = AsyncMock()
+    camera._api._api_key = "test_api_key"
+    camera._api.get_camera_rtsps_streams = AsyncMock(
+        return_value=RTSPSStreams(
+            high="rtsps://example.com/high",
+            medium="rtsps://example.com/medium"
+        )
+    )
+    
+    # Bind the actual method to the mock
+    from uiprotect.data.devices import Camera
+    camera.get_rtsps_streams = Camera.get_rtsps_streams.__get__(camera, Camera)
+    
+    # Test successful retrieval
+    result = await camera.get_rtsps_streams()
+    assert result is not None
+    assert result.get_stream_url("high") == "rtsps://example.com/high"
+    assert result.get_stream_url("medium") == "rtsps://example.com/medium"
+    camera._api.get_camera_rtsps_streams.assert_called_once_with("test_camera_id")
+
+
+@pytest.mark.asyncio
+async def test_camera_get_rtsps_streams_no_api_key():
+    """Test Camera.get_rtsps_streams method without API key."""
+    from uiprotect.data import Camera
+    from uiprotect.exceptions import NotAuthorized
+    
+    # Mock camera and API without key
+    camera = AsyncMock(spec=Camera)
+    camera.id = "test_camera_id"
+    camera._api = AsyncMock()
+    camera._api._api_key = None
+    
+    # Bind the actual method to the mock
+    from uiprotect.data.devices import Camera
+    camera.get_rtsps_streams = Camera.get_rtsps_streams.__get__(camera, Camera)
+    
+    # Test that it raises NotAuthorized
+    with pytest.raises(NotAuthorized, match="Cannot get RTSPS streams without an API key"):
+        await camera.get_rtsps_streams()
+
+
+@pytest.mark.asyncio
+async def test_camera_delete_rtsps_streams():
+    """Test Camera.delete_rtsps_streams method."""
+    from uiprotect.data import Camera
+    
+    # Mock camera and API
+    camera = AsyncMock(spec=Camera)
+    camera.id = "test_camera_id"
+    camera._api = AsyncMock()
+    camera._api._api_key = "test_api_key"
+    camera._api.delete_camera_rtsps_streams = AsyncMock(return_value=True)
+    
+    # Bind the actual method to the mock
+    from uiprotect.data.devices import Camera
+    camera.delete_rtsps_streams = Camera.delete_rtsps_streams.__get__(camera, Camera)
+    
+    # Test successful deletion
+    result = await camera.delete_rtsps_streams(["high", "medium"])
+    assert result is True
+    camera._api.delete_camera_rtsps_streams.assert_called_once_with("test_camera_id", ["high", "medium"])
+
+
+@pytest.mark.asyncio
+async def test_camera_delete_rtsps_streams_no_api_key():
+    """Test Camera.delete_rtsps_streams method without API key."""
+    from uiprotect.data import Camera
+    from uiprotect.exceptions import NotAuthorized
+    
+    # Mock camera and API without key
+    camera = AsyncMock(spec=Camera)
+    camera.id = "test_camera_id"
+    camera._api = AsyncMock()
+    camera._api._api_key = None
+    
+    # Bind the actual method to the mock
+    from uiprotect.data.devices import Camera
+    camera.delete_rtsps_streams = Camera.delete_rtsps_streams.__get__(camera, Camera)
+    
+    # Test that it raises NotAuthorized
+    with pytest.raises(NotAuthorized, match="Cannot delete RTSPS streams without an API key"):
+        await camera.delete_rtsps_streams(["high"])


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
add publicapi RTSPS streams management for cameras with create, get, and delete functionalities
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
