### PR TITLE
fix(deps): remove typer dependency to resolve Home Assistant version conflicts

### DIFF
--- a/src/uiprotect/test_util/anonymize.py
+++ b/src/uiprotect/test_util/anonymize.py
@@ -6,8 +6,6 @@ import uuid
 from typing import Any
 from urllib.parse import urlparse
 
-import typer
-
 from ..data import ModelType
 
 object_id_mapping: dict[str, str] = {}
@@ -111,7 +109,7 @@ def anonymize_dict(obj: dict[str, Any], name: str | None = None) -> dict[str, An
         if obj["modelKey"] in [m.value for m in ModelType]:
             obj_type = ModelType(obj["modelKey"])
         else:
-            typer.secho(f"Unknown modelKey: {obj['modelKey']}", fg="yellow")
+            print(f"Warning: Unknown modelKey: {obj['modelKey']}")
 
     if obj_type == ModelType.USER:
         return anonymize_user(obj)

--- a/src/uiprotect/test_util/anonymize.py
+++ b/src/uiprotect/test_util/anonymize.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import secrets
 import string
 import uuid
+import warnings
 from typing import Any
 from urllib.parse import urlparse
 
@@ -109,7 +110,7 @@ def anonymize_dict(obj: dict[str, Any], name: str | None = None) -> dict[str, An
         if obj["modelKey"] in [m.value for m in ModelType]:
             obj_type = ModelType(obj["modelKey"])
         else:
-            print(f"Warning: Unknown modelKey: {obj['modelKey']}")
+            warnings.warn(f"Unknown modelKey: {obj['modelKey']}", stacklevel=2)
 
     if obj_type == ModelType.USER:
         return anonymize_user(obj)


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Removes the `typer` dependency from the project to resolve version conflicts reported by Home Assistant users.

The only usage of `typer` was in `src/uiprotect/test_util/anonymize.py` where `typer.secho()` was used to display a colored warning message. This has been replaced with Python's standard `warnings.warn()` with appropriate `stacklevel=2` parameter, following best practices for warning handling.

This change eliminates dependency conflicts that users have been experiencing when integrating with Home Assistant, where multiple integrations may require different versions of typer.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` - N/A (user-reported issue)
- [ ] There are new or updated unit tests validating the change - N/A (removal of dependency only)
- [ ] Documentation has been updated to reflect this change - N/A (internal change)
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced colored/CLI-specific warning output with a standard runtime warning; displayed message remains unchanged and behavior is otherwise the same.

* **Chores**
  * Removed an external CLI dependency, reducing the dependency footprint and simplifying installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->