### PR TITLE
fix: make rx_bytes and tx_bytes optional in CameraStats

### DIFF
--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -694,8 +694,8 @@ class StorageStats(ProtectBaseObject):
 
 
 class CameraStats(ProtectBaseObject):
-    rx_bytes: int
-    tx_bytes: int
+    rx_bytes: int | None = None  # deprecated: removed in Protect 6.1+
+    tx_bytes: int | None = None  # deprecated: removed in Protect 6.1+
     wifi: WifiStats
     video: VideoStats
     storage: StorageStats | None = None

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -527,8 +527,11 @@ async def test_ws_event_update(
     camera_before = get_camera().model_copy()
 
     new_stats = camera_before.stats.unifi_dict()
-    new_stats["rxBytes"] += 100
-    new_stats["txBytes"] += 100
+    # rxBytes and txBytes were removed in Protect 6.1+, handle both cases
+    if new_stats.get("rxBytes") is not None:
+        new_stats["rxBytes"] += 100
+    if new_stats.get("txBytes") is not None:
+        new_stats["txBytes"] += 100
     new_stats["video"]["recordingEnd"] = to_js_time(now)
     new_stats_unifi = camera_before.unifi_dict(data={"stats": deepcopy(new_stats)})
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

These fields were removed in UniFi Protect 6.1+. Making them optional ensures backwards compatibility with older Protect versions while supporting newer versions that no longer include these stats.

Fixes #584

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced API compatibility with upcoming Protect versions. Network traffic statistics metrics are now optional, enabling graceful operation when these values become unavailable in future releases. All existing functionality remains unchanged, ensuring full backward compatibility across current and future Protect versions. Related testing infrastructure was updated to reflect these changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->