### PR TITLE
Add test coverage for JSON deserialization in api_request (#98)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,12 @@ async def cleanup_client(client: ProtectApiClient):
     await client.close_public_api_session()
 
 
+@pytest.fixture
+def simple_api_client():
+    """Create a simple ProtectApiClient for unit testing without mocked bootstrap."""
+    return ProtectApiClient("test.com", 443, "username", "password")
+
+
 @pytest_asyncio.fixture(name="protect_client")
 async def protect_client_fixture():
     client = ProtectApiClient(


### PR DESCRIPTION

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

- Add tests for successful JSON parsing (dict, list, empty response)
- Add tests for JSONDecodeError handling (invalid syntax, truncated, binary data)
- Add tests for api_request_obj type validation
- Add tests for api_request_list type validation
- Add tests for complex nested JSON and unicode handling
- Add simple_api_client fixture to conftest.py for reusability

Fixes https://github.com/uilibs/uiprotect/issues/98

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for API request JSON deserialization handling, including edge cases and error scenarios to ensure reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->