### PR TITLE
test: add unit tests for _auth_websocket method

### DIFF
--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -7,6 +7,7 @@ import base64
 import logging
 from copy import deepcopy
 from datetime import datetime, timedelta
+from http.cookies import SimpleCookie
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1353,7 +1354,11 @@ async def test_auth_websocket_with_force_clears_session_cookies(
     """Test _auth_websocket with force=True clears session cookie jar."""
     protect_client = protect_client_no_debug
     session = await protect_client.get_session()
-    session.cookie_jar.update_cookies({"test_cookie": "test_value"})
+    cookies = SimpleCookie()
+    cookies["test_cookie"] = "test_value"
+    session.cookie_jar.update_cookies(cookies)
+    # Verify cookie was actually added before testing removal
+    assert len(list(session.cookie_jar)) > 0
 
     await protect_client._auth_websocket(force=True)
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Add comprehensive unit tests for the _auth_websocket method as requested in issue #97. Tests cover:

- force=False preserves authentication state
- force=True clears auth state (cookie, csrf-token, _is_authenticated)
- force=True clears session cookie jar
- Method returns headers dictionary
- ensure_authenticated is called
- Edge case when session is None

Fixes #97

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for websocket authentication flows, including verification of session cookie clearing, auth state reset, and proper header handling.
  * Added tests ensuring authentication checks run both with and without forced reset, and coverage for scenarios with no existing session.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->