### PR TITLE
fix: allow DNS hostnames with override_connection_host (#679)

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -1075,7 +1075,7 @@ class ProtectApiClient(BaseApiClient):
         self._update_lock = asyncio.Lock()
 
         if override_connection_host:
-            self._connection_host = ip_address(self._host)
+            self._connection_host = self._host
 
         if debug:
             set_debug()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -321,18 +321,17 @@ def test_connection_host_with_hostname_fallback(protect_client: ProtectApiClient
 
 
 @pytest.mark.parametrize(
-    ("host", "expected_type", "expected_value"),
+    ("host",),
     [
-        ("127.0.0.1", IPv4Address, IPv4Address("127.0.0.1")),
-        ("2001:db8::1", IPv6Address, IPv6Address("2001:db8::1")),
-        ("192.168.1.100", IPv4Address, IPv4Address("192.168.1.100")),
-        ("fe80::1", IPv6Address, IPv6Address("fe80::1")),
+        ("127.0.0.1",),
+        ("2001:db8::1",),
+        ("192.168.1.100",),
+        ("fe80::1",),
+        ("unifi.local",),
     ],
 )
-def test_connection_host_override(
-    host: str, expected_type: type, expected_value: IPv4Address | IPv6Address
-):
-    """Test override_connection_host with various IP addresses."""
+def test_connection_host_override(host: str):
+    """Test override_connection_host stores host as-is (string)."""
     protect = ProtectApiClient(
         host,
         443,
@@ -342,23 +341,9 @@ def test_connection_host_override(
         store_sessions=False,
     )
 
-    assert protect._connection_host == expected_value
-    assert isinstance(protect._connection_host, expected_type)
-
-
-def test_connection_host_override_hostname_fails():
-    """Test that override_connection_host with hostname raises ValueError."""
-    with pytest.raises(
-        ValueError, match="does not appear to be an IPv4 or IPv6 address"
-    ):
-        ProtectApiClient(
-            "unifi.local",
-            443,
-            "test",
-            "test",
-            override_connection_host=True,
-            store_sessions=False,
-        )
+    # Host is always stored as string, format_host_for_url handles formatting
+    assert protect._connection_host == host
+    assert isinstance(protect._connection_host, str)
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
The IPv6 support commit (958f139) changed ip_from_host() to async, but replaced it with ip_address() in __init__ which doesn't resolve DNS hostnames. This caused a ValueError when using hostnames like 'unifi.local' with override_connection_host=True.

Fix: Simply store the host string as-is. The format_host_for_url() function already handles both IP addresses and hostnames correctly.

Fixes https://github.com/uilibs/uiprotect/issues/679
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection host override handling to store host values as strings

* **Tests**
  * Updated connection host override tests to verify string-based storage

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->