### PR TITLE
feat: add rate limiter for public API requests

### DIFF
--- a/src/uiprotect/rate_limiter.py
+++ b/src/uiprotect/rate_limiter.py
@@ -1,0 +1,157 @@
+"""Rate limiting utilities for UniFi Protect API requests."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+
+
+class RateLimiter:
+    """
+    Async rate limiter using a sliding window algorithm.
+
+    This rate limiter ensures that no more than `max_requests` are made
+    within a rolling `window_seconds` time window. It is designed to
+    prevent hitting the UniFi Protect API rate limit of 10 requests/second.
+
+    Usage:
+        limiter = RateLimiter(max_requests=10, window_seconds=1.0)
+        await limiter.acquire()  # Blocks if rate limit would be exceeded
+        # ... make API request ...
+    """
+
+    def __init__(
+        self,
+        max_requests: int = 10,
+        window_seconds: float = 1.0,
+    ) -> None:
+        """
+        Initialize the rate limiter.
+
+        Args:
+            max_requests: Maximum number of requests allowed in the time window.
+                          Default is 10 (matching UniFi Protect's limit).
+            window_seconds: Size of the sliding window in seconds.
+                            Default is 1.0 second.
+
+        """
+        self._max_requests = max_requests
+        self._window_seconds = window_seconds
+        self._timestamps: deque[float] = deque()
+        self._lock: asyncio.Lock | None = None
+
+    def _get_lock(self) -> asyncio.Lock:
+        """
+        Get or create the lock in the current event loop.
+
+        Note: There's a theoretical race condition here where two coroutines
+        could create separate locks. However, this is benign because:
+        1. It only happens on first access
+        2. Python's GIL ensures the assignment is atomic
+        3. After first successful assignment, all coroutines use the same lock
+        """
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    @property
+    def max_requests(self) -> int:
+        """Maximum number of requests allowed in the time window."""
+        return self._max_requests
+
+    @property
+    def window_seconds(self) -> float:
+        """Size of the sliding window in seconds."""
+        return self._window_seconds
+
+    def _cleanup_old_timestamps(self, now: float) -> None:
+        """Remove timestamps that are outside the current window."""
+        cutoff = now - self._window_seconds
+        while self._timestamps and self._timestamps[0] < cutoff:
+            self._timestamps.popleft()
+
+    async def acquire(self) -> None:
+        """
+        Acquire permission to make a request.
+
+        This method will block (sleep) if making a request now would
+        exceed the rate limit. Once the method returns, the caller
+        is free to make their API request.
+
+        Note: Uses asyncio.sleep() which is non-blocking and yields
+        control back to the event loop, making it safe for use with
+        Home Assistant and other async frameworks.
+        """
+        async with self._get_lock():
+            now = time.monotonic()
+            self._cleanup_old_timestamps(now)
+
+            if len(self._timestamps) >= self._max_requests:
+                # Need to wait until the oldest request falls outside the window
+                oldest = self._timestamps[0]
+                wait_time = self._window_seconds - (now - oldest)
+                if wait_time > 0:
+                    await asyncio.sleep(wait_time)
+                    now = time.monotonic()
+                    self._cleanup_old_timestamps(now)
+
+            self._timestamps.append(now)
+
+    async def acquire_with_timeout(self, timeout: float) -> bool:
+        """
+        Try to acquire permission to make a request with a timeout.
+
+        Args:
+            timeout: Maximum time to wait in seconds.
+
+        Returns:
+            True if permission was acquired, False if timeout was reached.
+
+        """
+        try:
+            await asyncio.wait_for(self.acquire(), timeout=timeout)
+            return True
+        except TimeoutError:
+            return False
+
+    def get_wait_time(self) -> float:
+        """
+        Get the estimated wait time before a request can be made.
+
+        Note: This is an estimate and not thread-safe. For accurate
+        rate limiting, always use acquire().
+
+        Returns:
+            Estimated wait time in seconds. Returns 0.0 if a request
+            can be made immediately.
+
+        """
+        now = time.monotonic()
+        self._cleanup_old_timestamps(now)
+
+        if len(self._timestamps) < self._max_requests:
+            return 0.0
+
+        oldest = self._timestamps[0]
+        wait_time = self._window_seconds - (now - oldest)
+        return max(0.0, wait_time)
+
+    def get_available_requests(self) -> int:
+        """
+        Get the number of requests that can be made immediately.
+
+        Note: This is an estimate and not thread-safe. For accurate
+        rate limiting, always use acquire().
+
+        Returns:
+            Number of requests that can be made without waiting.
+
+        """
+        now = time.monotonic()
+        self._cleanup_old_timestamps(now)
+        return max(0, self._max_requests - len(self._timestamps))
+
+    def reset(self) -> None:
+        """Reset the rate limiter, clearing all recorded timestamps."""
+        self._timestamps.clear()

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,230 @@
+"""Tests for uiprotect.rate_limiter."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from uiprotect.rate_limiter import RateLimiter
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def limiter() -> RateLimiter:
+    """Create a rate limiter with default settings (10 req/sec)."""
+    return RateLimiter()
+
+
+@pytest.fixture
+def fast_limiter() -> RateLimiter:
+    """Create a rate limiter with small window for fast tests."""
+    return RateLimiter(max_requests=3, window_seconds=0.1)
+
+
+# --- Test Initialization and Properties ---
+
+
+class TestRateLimiterInit:
+    """Tests for RateLimiter initialization and properties."""
+
+    def test_default_values(self, limiter: RateLimiter) -> None:
+        """Test default initialization values."""
+        assert limiter.max_requests == 10
+        assert limiter.window_seconds == 1.0
+
+    @pytest.mark.parametrize(
+        ("max_requests", "window_seconds"),
+        [
+            (5, 2.0),
+            (100, 0.5),
+            (1, 10.0),
+        ],
+    )
+    def test_custom_values(self, max_requests: int, window_seconds: float) -> None:
+        """Test custom initialization values."""
+        limiter = RateLimiter(max_requests=max_requests, window_seconds=window_seconds)
+        assert limiter.max_requests == max_requests
+        assert limiter.window_seconds == window_seconds
+
+
+# --- Test Core Acquire Functionality ---
+
+
+class TestAcquire:
+    """Tests for the acquire() method."""
+
+    @pytest.mark.asyncio
+    async def test_acquire_under_limit(self, fast_limiter: RateLimiter) -> None:
+        """Test acquiring when under the rate limit."""
+        for _ in range(fast_limiter.max_requests):
+            await fast_limiter.acquire()
+        # Should complete without blocking significantly
+        assert fast_limiter.get_available_requests() == 0
+
+    @pytest.mark.asyncio
+    async def test_acquire_at_limit_waits(self) -> None:
+        """Test that acquire() waits when at rate limit."""
+        limiter = RateLimiter(max_requests=2, window_seconds=0.05)
+
+        # Fill up the limit
+        await limiter.acquire()
+        await limiter.acquire()
+
+        # Next acquire should wait
+        start = time.monotonic()
+        await limiter.acquire()
+        elapsed = time.monotonic() - start
+
+        # Should have waited approximately window_seconds
+        assert elapsed >= 0.04  # Allow some tolerance
+
+    @pytest.mark.asyncio
+    async def test_acquire_creates_lock_lazily(self, limiter: RateLimiter) -> None:
+        """Test that lock is created on first acquire."""
+        assert limiter._lock is None
+        await limiter.acquire()
+        assert limiter._lock is not None
+
+
+# --- Test acquire_with_timeout ---
+
+
+class TestAcquireWithTimeout:
+    """Tests for the acquire_with_timeout() method."""
+
+    @pytest.mark.asyncio
+    async def test_acquire_with_timeout_success(
+        self, fast_limiter: RateLimiter
+    ) -> None:
+        """Test successful acquisition within timeout."""
+        result = await fast_limiter.acquire_with_timeout(timeout=1.0)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_acquire_with_timeout_failure(self) -> None:
+        """Test timeout when rate limit is exceeded."""
+        limiter = RateLimiter(max_requests=1, window_seconds=1.0)
+
+        # Use up the limit
+        await limiter.acquire()
+
+        # Try to acquire with very short timeout - should fail
+        result = await limiter.acquire_with_timeout(timeout=0.01)
+        assert result is False
+
+
+# --- Test get_wait_time ---
+
+
+class TestGetWaitTime:
+    """Tests for the get_wait_time() method."""
+
+    def test_get_wait_time_empty(self, limiter: RateLimiter) -> None:
+        """Test wait time when no requests have been made."""
+        assert limiter.get_wait_time() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_get_wait_time_under_limit(self, fast_limiter: RateLimiter) -> None:
+        """Test wait time when under the limit."""
+        await fast_limiter.acquire()
+        assert fast_limiter.get_wait_time() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_get_wait_time_at_limit(self) -> None:
+        """Test wait time when at the rate limit."""
+        limiter = RateLimiter(max_requests=2, window_seconds=0.5)
+
+        await limiter.acquire()
+        await limiter.acquire()
+
+        wait_time = limiter.get_wait_time()
+        # Should be close to window_seconds since requests just happened
+        assert 0.0 < wait_time <= 0.5
+
+
+# --- Test get_available_requests ---
+
+
+class TestGetAvailableRequests:
+    """Tests for the get_available_requests() method."""
+
+    def test_get_available_requests_empty(self, limiter: RateLimiter) -> None:
+        """Test available requests when limiter is empty."""
+        assert limiter.get_available_requests() == limiter.max_requests
+
+    @pytest.mark.asyncio
+    async def test_get_available_requests_partial(
+        self, fast_limiter: RateLimiter
+    ) -> None:
+        """Test available requests after some requests."""
+        await fast_limiter.acquire()
+        await fast_limiter.acquire()
+        assert fast_limiter.get_available_requests() == 1
+
+    @pytest.mark.asyncio
+    async def test_get_available_requests_full(self, fast_limiter: RateLimiter) -> None:
+        """Test available requests when at limit."""
+        for _ in range(fast_limiter.max_requests):
+            await fast_limiter.acquire()
+        assert fast_limiter.get_available_requests() == 0
+
+    @pytest.mark.asyncio
+    async def test_get_available_requests_after_window(self) -> None:
+        """Test that requests become available after window expires."""
+        limiter = RateLimiter(max_requests=2, window_seconds=0.05)
+
+        await limiter.acquire()
+        await limiter.acquire()
+        assert limiter.get_available_requests() == 0
+
+        # Wait for window to expire
+        await asyncio.sleep(0.06)
+        assert limiter.get_available_requests() == 2
+
+
+# --- Test reset ---
+
+
+class TestReset:
+    """Tests for the reset() method."""
+
+    @pytest.mark.asyncio
+    async def test_reset_clears_timestamps(self, fast_limiter: RateLimiter) -> None:
+        """Test that reset clears all recorded timestamps."""
+        # Fill up the limiter
+        for _ in range(fast_limiter.max_requests):
+            await fast_limiter.acquire()
+
+        assert fast_limiter.get_available_requests() == 0
+
+        # Reset and verify
+        fast_limiter.reset()
+        assert fast_limiter.get_available_requests() == fast_limiter.max_requests
+
+
+# --- Test timestamp cleanup ---
+
+
+class TestTimestampCleanup:
+    """Tests for the _cleanup_old_timestamps() method."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_old_timestamps(self) -> None:
+        """Test that old timestamps are cleaned up."""
+        limiter = RateLimiter(max_requests=5, window_seconds=0.05)
+
+        # Make some requests
+        await limiter.acquire()
+        await limiter.acquire()
+        assert len(limiter._timestamps) == 2
+
+        # Wait for window to expire
+        await asyncio.sleep(0.06)
+
+        # Trigger cleanup via get_available_requests
+        available = limiter.get_available_requests()
+        assert available == 5
+        assert len(limiter._timestamps) == 0


### PR DESCRIPTION
- Add RateLimiter class using sliding window algorithm (10 req/sec)
- Integrate rate limiting into BaseApiClient for public_api=True requests
- Add set_public_api_rate_limit() method for runtime configuration
- Add comprehensive tests with 100% coverage

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable rate limiting for API requests to prevent overload.
  * Default limit set to 10 requests per second.
  * Runtime adjustment capability for rate limiting parameters.

* **Tests**
  * Added comprehensive test coverage for rate limiting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->