### PR TITLE
feat: record public API websockets during sample data generation

### DIFF
--- a/src/uiprotect/test_util/__init__.py
+++ b/src/uiprotect/test_util/__init__.py
@@ -252,6 +252,11 @@ class SampleDataGenerator:
 
         self._record_listen_for_events = False
         await self.client.async_disconnect_ws()
+
+        if has_public_api:
+            events_ws.stop()
+            devices_ws.stop()
+
         await self.write_json_file(
             "sample_ws_messages",
             self._record_ws_messages,
@@ -674,8 +679,9 @@ class SampleDataGenerator:
             try:
                 data = orjson.loads(msg.data)
             except (orjson.JSONDecodeError, TypeError) as exc:
+                preview = str(msg.data)[:200]
                 self.log_warning(
-                    f"Failed to parse public API WS message: {msg.data} ({exc})"
+                    f"Failed to parse public API WS message: {preview} ({exc})"
                 )
                 return
 


### PR DESCRIPTION
Add parallel recording of both public API websockets (events + devices) alongside the existing private websocket during generate-sample-data.

- Events WS: /proxy/protect/integration/v1/subscribe/events
- Devices WS: /proxy/protect/integration/v1/subscribe/devices

Output files: sample_ws_events_public.json, sample_ws_devices_public.json Requires API key (UFP_API_KEY), skipped gracefully if not set.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
Extends `SampleDataGenerator` to also record both public API WebSocket endpoints (events + devices) alongside the private WS during sample data generation.

- Records `/proxy/protect/integration/v1/subscribe/events` → `sample_ws_events_public.json`
- Records `/proxy/protect/integration/v1/subscribe/devices` → `sample_ws_devices_public.json`
- Only activates when API key is configured
- All 3 WS connections run in parallel
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test utilities to record public API WebSocket messages for events and devices, capture time-offset sequences, apply optional anonymization, handle malformed messages gracefully, and export sampled WS data for improved real-time scenario testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->