### PR TITLE
fix: bound Bootstrap.events to prevent unbounded memory growth

### DIFF
--- a/src/uiprotect/data/bootstrap.py
+++ b/src/uiprotect/data/bootstrap.py
@@ -194,7 +194,9 @@ class Bootstrap(ProtectBaseObject):
     # not directly from UniFi
     keyrings: Keyrings = Keyrings()
     ulp_users: UlpUsers = UlpUsers()
-    events: dict[str, Event] = FixSizeOrderedDict()
+    events: dict[str, Event] = FixSizeOrderedDict(
+        max_size=MAX_EVENT_HISTORY_IN_STATE_MACHINE
+    )
     capture_ws_stats: bool = False
     mac_lookup: dict[str, ProtectDeviceRef] = {}
     id_lookup: dict[str, ProtectDeviceRef] = {}

--- a/tests/data/test_common.py
+++ b/tests/data/test_common.py
@@ -43,6 +43,7 @@ from uiprotect.data import (
     WSPacket,
     create_from_unifi_dict,
 )
+from uiprotect.data.bootstrap import MAX_EVENT_HISTORY_IN_STATE_MACHINE
 from uiprotect.data.devices import LCDMessage
 from uiprotect.data.nvr import EventMetadata
 from uiprotect.data.types import RecordingType, ResolutionStorageType
@@ -301,6 +302,41 @@ def test_camera_smart_audio_events(camera_obj: Camera):
     assert camera_obj.last_smoke_detect_event.id == "test_event_1"
     assert camera_obj.last_cmonx_detect_event is not None
     assert camera_obj.last_cmonx_detect_event.id == "test_event_2"
+
+
+@pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
+def test_bootstrap_events_are_bounded(camera_obj: Camera):
+    """
+    Bootstrap.events must evict old entries so the in-memory cache is bounded.
+
+    Previously this dict was an unbounded ``FixSizeOrderedDict()`` — every
+    incoming event accumulated forever. The cap is
+    ``MAX_EVENT_HISTORY_IN_STATE_MACHINE`` and is enforced by
+    ``FixSizeOrderedDict.__setitem__``.
+    """
+    bootstrap = camera_obj.api.bootstrap
+    bootstrap.events.clear()
+    now = utc_now()
+
+    # Push one more event than the cap — the oldest should be evicted.
+    overfill = MAX_EVENT_HISTORY_IN_STATE_MACHINE + 10
+    for i in range(overfill):
+        event = Event(  # type: ignore[call-arg]
+            api=camera_obj.api,
+            id=f"bounded_event_{i}",
+            camera_id=camera_obj.id,
+            start=now - timedelta(seconds=overfill - i),
+            type=EventType.MOTION,
+            score=0,
+            smart_detect_types=[],
+            smart_detect_event_ids=[],
+        )
+        bootstrap.process_event(event)
+
+    assert len(bootstrap.events) == MAX_EVENT_HISTORY_IN_STATE_MACHINE
+    # Oldest insertions evicted, newest retained.
+    assert "bounded_event_0" not in bootstrap.events
+    assert f"bounded_event_{overfill - 1}" in bootstrap.events
 
 
 def test_bootstrap(bootstrap: dict[str, Any]):


### PR DESCRIPTION
### Description of change

\`Bootstrap.events\` has been declared as \`FixSizeOrderedDict()\` with the default \`max_size=0\` — i.e. **unbounded**. Every incoming websocket event is appended via \`self.events[event.id] = event\` (\`bootstrap.py\`) and **nothing** in the codebase evicts entries, so long-running installations (Home Assistant, etc.) accumulate every event forever.

\`MAX_EVENT_HISTORY_IN_STATE_MACHINE\` (\`MAX_SUPPORTED_CAMERAS * 2 = 512\`) is already defined at the top of \`bootstrap.py\` in anticipation of exactly this cap but was never actually passed to \`FixSizeOrderedDict\`. This PR wires it up so the oldest entries are evicted once the cap is exceeded.

This was surfaced during review of #778 — Copilot originally flagged it on the (now-replaced) linear scan of \`bootstrap.events\`, and we decided to split the cap into its own PR to keep #778 focused on the overlap fix.

**Impact**

- Properties like \`Camera.last_motion_event\` / \`last_ring_event\` that look up \`bootstrap.events.get(id)\` will return \`None\` for events older than the cap. This is strictly better than the alternative (unbounded growth eventually OOM-ing the process), and in practice the cap is large enough to keep the last-N references fresh for typical event rates. Smart-detect properties already fall back to the per-camera active index (\`_active_smart_detect_events\`) added in #778 and are unaffected.

### Test plan

New test \`test_bootstrap_events_are_bounded\` pushes \`MAX_EVENT_HISTORY_IN_STATE_MACHINE + 10\` motion events through \`bootstrap.process_event\` and asserts:

1. \`len(bootstrap.events) == MAX_EVENT_HISTORY_IN_STATE_MACHINE\` after overflow
2. The first-inserted id has been evicted
3. The most-recent id is still present

Full \`tests/data/test_common.py\` suite passes locally (83 tests).

### Pull-Request Checklist

- [x] Code is up-to-date with the \`main\` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as \`Fixes #0000\` — N/A (internal leak, no issue filed)
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change — N/A
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/).