### PR TITLE
Fix stripping of all instances of -e in thumbnail and heatmap generations

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -2630,7 +2630,7 @@ class ProtectApiClient(BaseApiClient):
             params.update({"h": height})
 
         # old thumbnail URL use thumbnail ID, which is just `e-{event_id}`
-        thumbnail_id = thumbnail_id.replace("e-", "")
+        thumbnail_id = thumbnail_id.removeprefix("e-")
         return await self._get_image_with_retry(
             f"events/{thumbnail_id}/thumbnail",
             params=params,
@@ -2666,7 +2666,7 @@ class ProtectApiClient(BaseApiClient):
             params.update({"h": height})
 
         # old thumbnail URL use thumbnail ID, which is just `e-{event_id}`
-        thumbnail_id = thumbnail_id.replace("e-", "")
+        thumbnail_id = thumbnail_id.removeprefix("e-")
         return await self._get_image_with_retry(
             f"events/{thumbnail_id}/animated-thumbnail",
             params=params,
@@ -2687,7 +2687,7 @@ class ProtectApiClient(BaseApiClient):
         your retry timeout will always return None.
         """
         # old heatmap URL use heatmap ID, which is just `e-{event_id}`
-        heatmap_id = heatmap_id.replace("e-", "")
+        heatmap_id = heatmap_id.removeprefix("e-")
         return await self._get_image_with_retry(
             f"events/{heatmap_id}/heatmap",
             retry_timeout=retry_timeout,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1249,12 +1249,12 @@ async def test_get_event_thumbnail_uuid_with_e_dash(protect_client: ProtectApiCl
     )
 
 
-`@pytest.mark.skipif`(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
-`@pytest.mark.asyncio`()
+@pytest.mark.skipif(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
+@pytest.mark.asyncio()
 async def test_get_event_animated_thumbnail_uuid_with_e_dash(
     protect_client: ProtectApiClient,
 ):
-    """Regression test for `#810`: event IDs containing 'e-' must not be corrupted."""
+    """Regression test for #810: event IDs containing 'e-' must not be corrupted."""
     event_id = "4028adde-42c6-4873-a49e-94da9bd22190"
     data = await protect_client.get_event_animated_thumbnail(event_id)
     assert data is not None
@@ -1265,22 +1265,6 @@ async def test_get_event_animated_thumbnail_uuid_with_e_dash(
         raise_exception=False,
     )
 
-
-`@pytest.mark.skipif`(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
-`@pytest.mark.asyncio`()
-async def test_get_event_animated_thumbnail_strips_legacy_prefix(
-    protect_client: ProtectApiClient,
-):
-    data = await protect_client.get_event_animated_thumbnail(
-        "e-4028adde-42c6-4873-a49e-94da9bd22190"
-    )
-    assert data is not None
-
-    protect_client.api_request_raw.assert_called_with(  # type: ignore[attr-defined]
-        "events/4028adde-42c6-4873-a49e-94da9bd22190/animated-thumbnail",
-        params={"keyFrameOnly": "true", "speedup": 10},
-        raise_exception=False,
-    )
 
 @pytest.mark.skipif(not TEST_HEATMAP_EXISTS, reason="Missing testdata")
 @pytest.mark.asyncio()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1249,12 +1249,12 @@ async def test_get_event_thumbnail_uuid_with_e_dash(protect_client: ProtectApiCl
     )
 
 
-@pytest.mark.skipif(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
-@pytest.mark.asyncio()
+`@pytest.mark.skipif`(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
+`@pytest.mark.asyncio`()
 async def test_get_event_animated_thumbnail_uuid_with_e_dash(
     protect_client: ProtectApiClient,
 ):
-    """Regression test for #810: event IDs containing 'e-' must not be corrupted."""
+    """Regression test for `#810`: event IDs containing 'e-' must not be corrupted."""
     event_id = "4028adde-42c6-4873-a49e-94da9bd22190"
     data = await protect_client.get_event_animated_thumbnail(event_id)
     assert data is not None
@@ -1265,6 +1265,22 @@ async def test_get_event_animated_thumbnail_uuid_with_e_dash(
         raise_exception=False,
     )
 
+
+`@pytest.mark.skipif`(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
+`@pytest.mark.asyncio`()
+async def test_get_event_animated_thumbnail_strips_legacy_prefix(
+    protect_client: ProtectApiClient,
+):
+    data = await protect_client.get_event_animated_thumbnail(
+        "e-4028adde-42c6-4873-a49e-94da9bd22190"
+    )
+    assert data is not None
+
+    protect_client.api_request_raw.assert_called_with(  # type: ignore[attr-defined]
+        "events/4028adde-42c6-4873-a49e-94da9bd22190/animated-thumbnail",
+        params={"keyFrameOnly": "true", "speedup": 10},
+        raise_exception=False,
+    )
 
 @pytest.mark.skipif(not TEST_HEATMAP_EXISTS, reason="Missing testdata")
 @pytest.mark.asyncio()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1234,6 +1234,68 @@ async def test_get_event_thumbnail_args(protect_client: ProtectApiClient):
     assert img.format in {"PNG", "JPEG"}
 
 
+@pytest.mark.skipif(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
+@pytest.mark.asyncio()
+async def test_get_event_thumbnail_uuid_with_e_dash(protect_client: ProtectApiClient):
+    """Regression test for #810: event IDs containing 'e-' must not be corrupted."""
+    event_id = "4028adde-42c6-4873-a49e-94da9bd22190"
+    data = await protect_client.get_event_thumbnail(event_id)
+    assert data is not None
+
+    protect_client.api_request_raw.assert_called_with(  # type: ignore[attr-defined]
+        f"events/{event_id}/thumbnail",
+        params={},
+        raise_exception=False,
+    )
+
+
+@pytest.mark.skipif(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
+@pytest.mark.asyncio()
+async def test_get_event_animated_thumbnail_uuid_with_e_dash(
+    protect_client: ProtectApiClient,
+):
+    """Regression test for #810: event IDs containing 'e-' must not be corrupted."""
+    event_id = "4028adde-42c6-4873-a49e-94da9bd22190"
+    data = await protect_client.get_event_animated_thumbnail(event_id)
+    assert data is not None
+
+    protect_client.api_request_raw.assert_called_with(  # type: ignore[attr-defined]
+        f"events/{event_id}/animated-thumbnail",
+        params={"keyFrameOnly": "true", "speedup": 10},
+        raise_exception=False,
+    )
+
+
+@pytest.mark.skipif(not TEST_HEATMAP_EXISTS, reason="Missing testdata")
+@pytest.mark.asyncio()
+async def test_get_event_heatmap_uuid_with_e_dash(protect_client: ProtectApiClient):
+    """Regression test for #810: event IDs containing 'e-' must not be corrupted."""
+    event_id = "4028adde-42c6-4873-a49e-94da9bd22190"
+    data = await protect_client.get_event_heatmap(event_id)
+    assert data is not None
+
+    protect_client.api_request_raw.assert_called_with(  # type: ignore[attr-defined]
+        f"events/{event_id}/heatmap",
+        raise_exception=False,
+    )
+
+
+@pytest.mark.skipif(not TEST_THUMBNAIL_EXISTS, reason="Missing testdata")
+@pytest.mark.asyncio()
+async def test_get_event_thumbnail_strips_legacy_prefix(
+    protect_client: ProtectApiClient,
+):
+    """Legacy thumbnail IDs of the form 'e-<event_id>' should have the prefix stripped."""
+    data = await protect_client.get_event_thumbnail("e-4028adde-42c6-4873-a49e-94da9bd22190")
+    assert data is not None
+
+    protect_client.api_request_raw.assert_called_with(  # type: ignore[attr-defined]
+        "events/4028adde-42c6-4873-a49e-94da9bd22190/thumbnail",
+        params={},
+        raise_exception=False,
+    )
+
+
 @pytest.mark.skipif(not TEST_HEATMAP_EXISTS, reason="Missing testdata")
 @pytest.mark.asyncio()
 async def test_get_event_heatmap(protect_client: ProtectApiClient):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1286,7 +1286,9 @@ async def test_get_event_thumbnail_strips_legacy_prefix(
     protect_client: ProtectApiClient,
 ):
     """Legacy thumbnail IDs of the form 'e-<event_id>' should have the prefix stripped."""
-    data = await protect_client.get_event_thumbnail("e-4028adde-42c6-4873-a49e-94da9bd22190")
+    data = await protect_client.get_event_thumbnail(
+        "e-4028adde-42c6-4873-a49e-94da9bd22190"
+    )
     assert data is not None
 
     protect_client.api_request_raw.assert_called_with(  # type: ignore[attr-defined]


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Replace instances of `.replace("e-", "")` with `.removeprefix("e-")` as all instances of `-e` were getting stripped in the thumbnail UUIDs resulting in 404s.

Example `event_id` `4028adde-42c6-4873-a49e-94da9bd22190` was being truncated to `4028add42c6-4873-a4994da9bd22190`.

Fixes #810 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected event image URL handling so legacy leading "e-" is removed only when present, preventing incorrect thumbnail/heatmap requests.

* **Tests**
  * Added regression tests covering thumbnails, animated thumbnails, and heatmaps — including cases with legacy "e-" prefixed event IDs to prevent future regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uilibs/uiprotect/pull/817)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->