### PR TITLE
docs: add AGENTS.md orientation file for LLM contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,281 @@
+# Notes for LLM contributors
+
+A short orientation file for an LLM working in this repo. Skim
+before making changes; keep edits consistent with what's described
+here. Read [README.md](README.md) for the user-facing intro and
+[CONTRIBUTING.md](CONTRIBUTING.md) for the human-facing
+contributor guide.
+
+## What this project is
+
+`uiprotect` is an unofficial async Python client + CLI for the
+UniFi Protect surveillance NVR. It is the library that the Home
+Assistant `unifiprotect` integration is built on top of, and it
+is the de-facto Python binding for talking to a UniFi Protect
+console — Ubiquiti does not publish an official one. Public API
+is exported from the top-level `uiprotect` package; the main
+entry point is `uiprotect.ProtectApiClient` in `src/uiprotect/api.py`.
+
+There is no upstream protocol owner. The wire format is whatever
+the UniFi Protect server in front of you serves: a partially
+documented REST API plus a binary WebSocket update stream. Both
+shift across firmware releases, and the test corpus under
+`tests/sample_data/` is the closest thing to a reference. Behaviour
+changes that depend on a specific Protect firmware version should
+say so in the commit message.
+
+The project was forked from `pyunifiprotect` after that project
+relicensed away from MIT; staying MIT-licensed is a hard
+requirement so the Home Assistant core integration can keep
+depending on it.
+
+## Code style
+
+- **Docstrings: terse, default to single-line.** A docstring is
+  the function's _contract_, not its narrative. Almost every
+  docstring should be one line — `"""Summary."""` — describing
+  what the function does and what the caller can pass. Multi-line
+  is the exception, only justified when there is non-obvious
+  caller-visible behaviour the type signature and parameter names
+  don't already convey. Ruff is configured with most of the `D`
+  family disabled (`D100`–`D107`, `D2xx`, `D4xx`) precisely so
+  that missing docstrings on internal helpers don't flag — only
+  add one when it earns its keep.
+
+  **What does NOT belong in docstrings or comments:**
+  - Rationale / motivation / "why we used to do X" — that's the
+    PR description and the commit message. Git already remembers.
+  - Cross-references to issue numbers ("closes #N", "follow-up
+    to #M") — the PR body carries those.
+  - Restatement of the function body in prose. If the next line
+    of the docstring is just describing what the next line of
+    code does, delete the docstring line.
+  - Test docstrings retelling the production-side story. A test
+    docstring should name what the test pins, in one sentence —
+    not re-explain the bug, the fix, or the surrounding flow.
+
+- **Comments**: same bar. Default to writing no comments. Add
+  one only when the _why_ is non-obvious: a hidden constraint, a
+  subtle invariant, a workaround for a specific Protect firmware
+  quirk, behaviour that would surprise a reader. Firmware-version
+  citations are useful when the reason for a branch is "this
+  server returns the field, that one doesn't" — leave those in.
+  If removing the comment wouldn't confuse a future reader, don't
+  write it.
+
+  **Don't remove existing comments** unless the code they
+  describe is gone — the original author left them for a reason,
+  often a specific Protect firmware regression.
+
+- **Don't pad commits, docstrings, or comments with cross-
+  references** to old codepaths or issue numbers unless there's
+  a clear reason a future reader needs that link.
+
+- **Method order**: public API at the top, private helpers
+  (`_underscore_prefixed`) at the bottom. The supported surface
+  is what `src/uiprotect/__init__.py` re-exports plus the public
+  attributes on `ProtectApiClient`, `Bootstrap`, and the device /
+  NVR model classes. Anything else is internal and can change
+  between releases.
+
+- **Line length**: 88 (ruff `line-length = 88`, not the more
+  common 100/110). `requires-python = ">=3.11"`,
+  `target-version = "py311"` for ruff; pyupgrade runs `--py311-plus`.
+
+- **Imports**: ruff/isort sorted, `known_first_party = ["uiprotect", "tests"]`.
+  Prefer `from __future__ import annotations` in new modules so
+  modern type syntax works without runtime forward-reference
+  juggling, especially given the pydantic model graph.
+
+- **Pydantic v2 only.** Models live under `src/uiprotect/data/`
+  and are built on pydantic v2 (`pydantic >= 2.13.4`). Do not
+  reintroduce v1 idioms (`.dict()`, `Config` inner class,
+  `validator` decorator) when touching this code — match the v2
+  style already present (`model_dump()`, `model_config`,
+  `field_validator`). The pinned-floor on pydantic is deliberate;
+  do not loosen it without checking what changed across versions.
+
+- **`orjson` for serialisation.** The codebase uses `orjson`
+  everywhere it serialises or parses Protect payloads. Don't
+  reach for stdlib `json` in hot paths; match the existing
+  `orjson.loads` / `orjson.dumps` usage.
+
+- **Async-only public surface.** UniFi Protect itself is async,
+  and so is this library. New public functions on
+  `ProtectApiClient` and friends should be `async def`. Don't
+  introduce sync wrappers around async I/O; callers that need
+  sync should drive the event loop themselves.
+
+- **Typed strictly.** mypy runs with `disallow_untyped_defs`,
+  `disallow_incomplete_defs`, `check_untyped_defs`,
+  `no_implicit_optional`, `warn_unreachable`, and
+  `warn_unused_ignores`, and is wired into pre-commit through
+  `.bin/run-mypy` against `src/uiprotect/`. New code under
+  `src/uiprotect/` must type-check cleanly; tests are exempted
+  via the `tests.*` override. Don't paper over a real type error
+  with `# type: ignore` — `warn_unused_ignores` will eventually
+  catch you, and the right answer is almost always a tighter
+  annotation upstream.
+
+## Commit / PR conventions
+
+- **Conventional Commits are enforced.** Pre-commit runs
+  `commitizen` on every commit message and CI runs commitlint
+  with `@commitlint/config-conventional`
+  (`commitlint.config.mjs`). The header / body / footer length
+  caps are all disabled (`header-max-length = [0, "always", Infinity]`),
+  but the _type_ prefix is required: `feat:`, `fix:`, `chore:`,
+  `ci:`, `docs:`, `refactor:`, `test:`, `perf:`, `build:`, etc.
+  `python-semantic-release` excludes `chore*` and `ci*` from the
+  changelog (see `[tool.semantic_release.changelog]` in
+  `pyproject.toml`), so use those prefixes for housekeeping and
+  reserve `feat`/`fix`/`perf` for user-visible changes that
+  should land in `CHANGELOG.md`.
+- **No `Co-Authored-By` trailers from automated agents.** Project
+  preference; releases are cut by `python-semantic-release` from
+  the commit log, and a trailer from an LLM ends up in the
+  generated changelog.
+- Imperative-mood subject after the type prefix ("fix(api):
+  handle empty bootstrap", not "fix(api): handled empty bootstrap").
+  Scopes in parentheses are encouraged where useful
+  (`api`, `cli`, `data`, `websocket`, `stream`).
+- The repo **does** ship a PR template at
+  [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).
+  Fill out the "Description of change" section in prose and tick
+  the checklist items that apply (write `N/A` rather than
+  silently leaving rows blank). Reference closing issues with
+  `Fixes #NNNN` so the issue auto-closes on merge.
+- Pre-commit runs ruff (lint + format), mypy, prettier,
+  commitizen, poetry-check, and the standard hygiene hooks
+  (trailing whitespace, end-of-file fixer, debug-statements,
+  detect-private-key, check-toml/xml). Run pre-commit locally
+  before pushing; the CI lint job is just `pre-commit run -a`,
+  so a green local run = a green CI lint job. The `pre-commit.ci`
+  bot fixes formatting drift automatically with a
+  `chore(pre-commit.ci): auto fixes` commit, so don't bother
+  hand-fixing whitespace-only failures.
+- **Releases are automated.** `python-semantic-release` cuts
+  releases from `main` based on commit type prefixes — `feat`
+  bumps minor, `fix`/`perf` bump patch, a `BREAKING CHANGE:`
+  footer (or `!` after the type) bumps major. Mis-typed commits
+  ship the wrong version. If a change is user-visible, type it
+  honestly.
+
+## Running tests
+
+```bash
+poetry run pytest
+```
+
+The default `addopts` in `pyproject.toml` already pass
+`-v -Wdefault --cov=uiprotect --cov-report=term-missing:skip-covered -n=auto`
+and `pythonpath = ["src"]`, so a bare `pytest` produces a
+coverage-aware, xdist-parallel run. `pytest-asyncio` is used in
+the default per-test mode (no auto mode); async tests are marked
+explicitly with `@pytest.mark.asyncio`.
+
+The test suite is fixture-driven: `tests/sample_data/` holds
+captured bootstrap JSON / WebSocket frames from real Protect
+consoles and `tests/conftest.py` loads them into the mock client.
+When fixing a bug that depends on a specific server response,
+add a fixture or extend an existing one rather than mocking ad-hoc
+in the test — the goal is for the corpus to grow alongside
+firmware drift. See [TESTDATA.md](TESTDATA.md) for how the corpus
+is generated.
+
+CodSpeed benchmarks live under `tests/benchmarks/` and run in CI
+through the CodSpeed integration. Don't regress benchmark numbers
+on hot paths (`api.py` request building, `data/convert.py`,
+`websocket.py` decode) without flagging the trade-off in the PR
+body.
+
+`tests/test_cli.py` covers the typer-based CLI surface. If you
+add a new subcommand under `src/uiprotect/cli/`, extend the CLI
+tests as well — the CLI tests are how we catch import-time
+regressions that would otherwise only fire for users on
+`uiprotect --help`.
+
+The CI matrix runs CPython 3.11 – 3.14 across Linux/macOS, and a
+separate live-data leg can run against a real Protect NVR on a
+self-hosted runner — see [LIVE_DATA_CI.md](LIVE_DATA_CI.md). The
+live leg is optional and is not gated for typical PRs.
+
+## Useful entry points
+
+| Path                                     | What                                                                             |
+| ---------------------------------------- | -------------------------------------------------------------------------------- |
+| `src/uiprotect/__init__.py`              | Public package — re-exports `ProtectApiClient` and key exceptions                |
+| `src/uiprotect/api.py`                   | `ProtectApiClient` — REST surface, auth, bootstrap, subscribe, request plumbing  |
+| `src/uiprotect/websocket.py`             | `Websocket` — the long-lived update connection that drives live state            |
+| `src/uiprotect/stream.py`                | PyAV-backed audio streaming to camera speakers (talkback)                        |
+| `src/uiprotect/utils.py`                 | Shared helpers: URL building, time parsing, type coercion, dict diffing          |
+| `src/uiprotect/exceptions.py`            | Public exception hierarchy raised from `ProtectApiClient`                        |
+| `src/uiprotect/data/__init__.py`         | Pydantic model re-exports — the typed surface most callers consume               |
+| `src/uiprotect/data/base.py`             | `ProtectBaseObject` / `ProtectModel` base classes shared by every Protect model  |
+| `src/uiprotect/data/bootstrap.py`        | `Bootstrap` — the cached snapshot returned by `protect.bootstrap`                |
+| `src/uiprotect/data/devices.py`          | Camera / Light / Sensor / Viewer / Chime / Doorlock / AiPort device models       |
+| `src/uiprotect/data/nvr.py`              | `NVR`, `Event`, `Liveview`, related top-level models                             |
+| `src/uiprotect/data/user.py`             | User / permission / cloud-account models                                         |
+| `src/uiprotect/data/websocket.py`        | WebSocket frame decoder + `WSSubscriptionMessage` definition                     |
+| `src/uiprotect/data/convert.py`          | Raw-JSON → pydantic-model conversion entry point used by API + WS paths          |
+| `src/uiprotect/data/types.py`            | Enums, typed dicts, and protocol-level constants                                 |
+| `src/uiprotect/data/public_bootstrap.py` | Public-API bootstrap shape (parallels `bootstrap.py` for the newer API)          |
+| `src/uiprotect/data/public_devices.py`   | Public-API device models                                                         |
+| `src/uiprotect/cli/`                     | typer-based CLI — one module per device family plus `base.py` for shared options |
+| `src/uiprotect/test_util/`               | Helpers used by `generate-sample-data`; not part of the public API               |
+| `tests/`                                 | Pytest suite                                                                     |
+| `tests/sample_data/`                     | Captured Protect bootstrap / WS / event JSON used as fixtures                    |
+| `tests/benchmarks/`                      | CodSpeed benchmarks                                                              |
+| `tests/conftest.py`                      | Fixture wiring: builds a mock `ProtectApiClient` from `sample_data/`             |
+| `templates/`                             | Rich templates used by the CLI for human-readable output                         |
+
+## Reporting security issues
+
+Suspected security vulnerabilities go through GitHub's private
+vulnerability reporting flow on the
+[uilibs/uiprotect](https://github.com/uilibs/uiprotect) repo,
+not public issues or pull requests. The library holds credentials
+for users' UniFi Protect consoles, so a bug class disclosed in a
+public PR title is a credible information leak even before a
+patch ships. If a user describes what sounds like a vulnerability
+in chat, point them at the private reporting route instead of
+opening a public issue, PR, or commit that names the bug class
+and the affected code path.
+
+## Things not to do
+
+- **Don't relicense or pull in non-MIT dependencies.** Staying
+  MIT is the reason this fork exists; an incompatible licence
+  would break the Home Assistant integration that depends on
+  this library.
+- **Don't break pydantic v2 compatibility.** No v1 idioms
+  (`.dict()`, `Config` inner class, `validator` decorator) when
+  editing model code — match the v2 style already in the
+  `src/uiprotect/data/` tree.
+- **Don't introduce sync wrappers around async I/O.** The public
+  surface is async; callers needing sync drive the loop
+  themselves.
+- **Don't paper over typing errors with `# type: ignore`.** mypy
+  runs with `warn_unused_ignores`, so a bare ignore will rot.
+  Fix the upstream annotation instead.
+- **Don't add `Co-Authored-By` trailers from automated agents
+  to commits** in this repo. `python-semantic-release` reads the
+  commit log when generating the changelog and the trailer
+  leaks into release notes.
+- **Don't introduce a commit message that violates Conventional
+  Commits.** The commitizen pre-commit hook and the CI
+  commitlint job will both reject it, and a mis-typed commit
+  bumps the wrong version on the next semantic-release run.
+- **Don't reach for stdlib `json` in hot paths.** The codebase
+  uses `orjson` everywhere; match the existing style.
+- **Don't hand-edit `CHANGELOG.md`.** It is generated by
+  `python-semantic-release` from commit messages; manual edits
+  are overwritten on the next release.
+- **Don't commit captured Protect data without scrubbing.**
+  Bootstrap and event JSON from a real NVR contains
+  `authUserId`, `accessKey`, and user records; see
+  [TESTDATA.md](TESTDATA.md) for the keys that must be removed
+  before a sample lands in `tests/sample_data/`.
+- **Don't drop Python 3.11 support without coordination.**
+  `requires-python = ">=3.11"` is set deliberately; the Home
+  Assistant integration's minimum tracks this floor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### Description of change

Adds an `AGENTS.md` orientation file for LLM contributors, in the
shape of the ones recently landed in `python-zeroconf/python-zeroconf#1672`
and `aio-libs/yarl`, adapted for this repo. `CLAUDE.md` is added as a
one-line `@AGENTS.md` reference so Claude Code picks up the same file
without duplicating its content.

The `AGENTS.md` covers:

- **What this project is** — async Python client + CLI for UniFi
  Protect, MIT fork of `pyunifiprotect`, consumed by the Home
  Assistant `unifiprotect` integration.
- **Code style** — single-line docstrings by default, comment
  discipline, ruff `line-length = 88`, `target-version = "py311"`,
  isort `known_first_party = ["uiprotect", "tests"]`, pydantic v2
  only (no `.dict()` / `validator` decorator / `Config` inner
  class), `orjson` for serialisation everywhere, async-only public
  surface, strict mypy on `src/uiprotect/` (with `warn_unused_ignores`
  so bare `# type: ignore` rots).
- **Commit / PR conventions** — Conventional Commits enforced via
  commitizen pre-commit + commitlint CI, no `Co-Authored-By` trailers
  from automated agents (semantic-release reads the log), imperative
  subjects, PR template at `.github/PULL_REQUEST_TEMPLATE.md`,
  `python-semantic-release` cuts releases from commit prefixes so
  mis-typed commits ship the wrong version.
- **Running tests** — `poetry run pytest` (the `pyproject.toml`
  `addopts` already pass `-n=auto`, `--cov=uiprotect`,
  `pythonpath = ["src"]`), fixture-driven via `tests/sample_data/`,
  CodSpeed benchmarks under `tests/benchmarks/`, optional live-data
  CI documented in `LIVE_DATA_CI.md`.
- **Useful entry points** table pointing at `api.py`, `websocket.py`,
  `stream.py`, the `data/` model layer (`base`, `bootstrap`,
  `devices`, `nvr`, `user`, `convert`, `types`, `public_*`),
  `exceptions.py`, `utils.py`, the typer `cli/` tree, and the
  fixture / benchmark directories.
- **Things not to do** — relicense or pull in non-MIT deps, mix in
  pydantic v1 idioms, introduce sync wrappers around async I/O,
  paper over typing errors with `# type: ignore`, add
  `Co-Authored-By` trailers from agents, violate Conventional
  Commits, reach for stdlib `json` in hot paths, hand-edit
  `CHANGELOG.md` (regenerated by semantic-release), commit
  unscrubbed Protect data into `tests/sample_data/`, or drop Python
  3.11 support.

No runtime code changes; this PR only adds contributor-facing
documentation.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` — N/A
- [ ] There are new or updated unit tests validating the change — N/A (docs only)
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contributor guidance documentation covering project conventions, testing practices, and development standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uilibs/uiprotect/pull/820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->