### PR TITLE
ci: scope release concurrency group per ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
 
     runs-on: ubuntu-latest
     environment: release
-    concurrency: release
+    concurrency:
+      group: release-${{ github.head_ref || github.ref }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## What

Scopes the `release` job's concurrency group per ref instead of a single shared `release` group.

## Why

The job-level `concurrency: release` is a global key across every branch and PR, so as soon as another PR's CI reaches the same job, the older run gets canceled (`Canceling since a higher priority waiting request for release exists`). The dry-run on PRs still serves as a validation step, so we want PRs to run independently while keeping main serialized.

With `release-${{ github.head_ref || github.ref }}`, each PR / branch gets its own group. On main it resolves to `release-refs/heads/main`, so actual releases still serialize. `cancel-in-progress: false` keeps queued jobs from killing each other; the workflow-level concurrency already cancels stale runs per head_ref.

Ports the same fix that landed in Bluetooth-Devices/dbus-fast#677.

## Checklist

- [x] CI scoped fix only; no library/runtime behavior change — N/A for changelog