### PR TITLE
docs: add SECURITY.md with private vulnerability reporting policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,16 +231,17 @@ live leg is optional and is not gated for typical PRs.
 
 ## Reporting security issues
 
-Suspected security vulnerabilities go through GitHub's private
-vulnerability reporting flow on the
-[uilibs/uiprotect](https://github.com/uilibs/uiprotect) repo,
-not public issues or pull requests. The library holds credentials
-for users' UniFi Protect consoles, so a bug class disclosed in a
-public PR title is a credible information leak even before a
-patch ships. If a user describes what sounds like a vulnerability
-in chat, point them at the private reporting route instead of
-opening a public issue, PR, or commit that names the bug class
-and the affected code path.
+Suspected security vulnerabilities go through GitHub's [private
+vulnerability reporting][gh-report], not public issues or pull
+requests. The policy is spelled out in [SECURITY.md](SECURITY.md).
+The library holds credentials for users' UniFi Protect consoles,
+so a bug class disclosed in a public PR title is a credible
+information leak even before a patch ships. If a user describes
+what sounds like a vulnerability in chat, point them at that
+route instead of opening a public issue, PR, or commit that
+names the bug class and the affected code path.
+
+[gh-report]: https://github.com/uilibs/uiprotect/security/advisories/new
 
 ## Things not to do
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately through GitHub's
+[private vulnerability reporting][gh-report] for this repository.
+That route sends the report directly to the maintainers and lets
+us coordinate a fix, a CVE, and a release before public
+disclosure.
+
+**Do not** open a regular GitHub issue, a pull request, or post
+to a public channel (mailing list, chat room, Stack Overflow,
+etc.) for a suspected vulnerability. The library holds
+credentials for users' UniFi Protect consoles, so a bug class
+disclosed in a public PR title is a credible information leak
+even before a patch ships. If you are unsure whether something
+is a vulnerability, use the private report — we would rather see
+a false alarm than a public one.
+
+We aim to acknowledge new reports within a few business days.
+
+[gh-report]: https://github.com/uilibs/uiprotect/security/advisories/new
+
+## Supported versions
+
+Security fixes are released against the latest version on PyPI.
+Older releases are not maintained — please upgrade to the
+current release before reporting, and confirm the issue still
+reproduces there.
+
+## Scope
+
+`uiprotect` is an async Python client for the UniFi Protect
+surveillance NVR. It authenticates against a Protect console
+with the user's credentials and parses REST responses plus a
+binary WebSocket update stream whose wire formats are not
+publicly documented and shift across firmware releases. In-scope
+issues include:
+
+- Memory-safety, parsing, or denial-of-service issues triggered
+  by crafted server responses reaching `ProtectApiClient`, the
+  WebSocket decoder in `data/websocket.py`, the JSON →
+  pydantic-model conversion in `data/convert.py`, or any of the
+  pydantic models under `src/uiprotect/data/`.
+- Credential or session-token handling bugs: logging or
+  serialising credentials, leaking the API token into logs or
+  exceptions, TLS validation that can be silently disabled, or
+  authentication state surviving where it should be cleared.
+- Logic bugs that cause the client to act on behalf of a
+  different user, expose data across NVR accounts, or persist
+  credentials to disk in unexpected locations.
+- Issues in the build / packaging pipeline (wheel contents,
+  release flow) that could lead to a compromised wheel on PyPI.
+
+Out of scope:
+
+- Risks inherent to handing the library credentials for a UniFi
+  Protect console — it is a client that drives the Protect API
+  on the user's behalf and inherits whatever permissions those
+  credentials carry.
+- Vulnerabilities in the upstream UniFi Protect server itself,
+  or in Ubiquiti firmware. Report those to Ubiquiti through
+  their published security channels, not here.
+- Misconfiguration of a downstream application that uses the
+  library (for example, the Home Assistant `unifiprotect`
+  integration).


### PR DESCRIPTION
## Summary

Add a `SECURITY.md` that directs vulnerability reports through GitHub's [private vulnerability reporting](https://github.com/uilibs/uiprotect/security/advisories/new), so reporters have a documented private channel and aren't tempted to open a public issue or PR. Cross-reference the policy from `AGENTS.md` so future LLM-assisted contributions route reports the same way.

## Details

- **`SECURITY.md`** — top-level file (where GitHub's Security tab looks for it). Names the supported channel, supported versions (latest release on PyPI), and an in-scope / out-of-scope list grounded in the project's actual attack surface: crafted REST or WebSocket payloads through `ProtectApiClient`, the WebSocket decoder in `data/websocket.py`, JSON → pydantic conversion in `data/convert.py`, and the pydantic models under `src/uiprotect/data/`; credential / session-token handling; cross-account logic bugs; the wheel / release pipeline. Out of scope: misuse of supplied console credentials (the library acts on the user's behalf), upstream Protect server / Ubiquiti firmware bugs, and downstream-app misconfig (e.g. the Home Assistant `unifiprotect` integration).
- **`AGENTS.md`** — existing `## Reporting security issues` section now links to `SECURITY.md` and uses a reference-style link to the private-reporting URL, matching the shape of the new policy file.

Modeled on python-zeroconf/python-zeroconf#1675.

## Test plan

- [ ] `SECURITY.md` is discoverable via GitHub's Security tab after merge (`/security/policy` resolves).
- [ ] The \"Report a vulnerability\" button on the Security tab leads to `/security/advisories/new`.
- [ ] `lint` and `commitlint` jobs are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated security vulnerability reporting procedures to direct issues to GitHub's private vulnerability reporting
* Added new security policy documenting vulnerability handling, supported versions, scope coverage, and reporting guidelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uilibs/uiprotect/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->