### PR TITLE
ci: allow release job checkout on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,10 @@ jobs:
       - lint
 
     runs-on: ubuntu-latest
-    environment: release
+    # Only enter the protected 'release' environment when actually releasing
+    # from main; PR dry-runs would otherwise be blocked by the env's
+    # main-only branch policy.
+    environment: ${{ github.ref_name == 'main' && 'release' || '' }}
     concurrency:
       group: release-${{ github.head_ref || github.ref }}
       cancel-in-progress: false
@@ -135,7 +138,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref || github.ref_name }}
-          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+          # Fall back to GITHUB_TOKEN on dependabot PRs, where
+          # secrets.BOT_ACCESS_TOKEN is not exposed and would otherwise
+          # leave actions/checkout's `token` input empty.
+          token: ${{ secrets.BOT_ACCESS_TOKEN || github.token }}
 
       - name: Setup Git
         run: |


### PR DESCRIPTION
### Description of change

On dependabot PRs the release job's checkout step fails with "Input required and not supplied: token" because `secrets.BOT_ACCESS_TOKEN` isn't exposed to dependabot runs, so the `token:` input ends up empty. This falls back to `github.token` so the PSR dry run can check the branch out; it also gates the protected `release` environment on main so PR runs aren't blocked by the env's branch policy. Mirrors the fix in Bluetooth-Devices/habluetooth#446.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow to conditionally activate release environments only on the main branch, providing stricter control over deployment processes
  * Improved authentication handling in automated workflows with fallback support for better compatibility across all pull request types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uilibs/uiprotect/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->