### PR TITLE
test: port session and video tests off sync io

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
+import aiofiles
 import aiohttp
 import av
 import pytest
@@ -38,27 +39,7 @@ _BENCHMARKS_DIR = "tests/benchmarks"
 # Tests that perform sync IO inside the asyncio event loop and trip
 # blockbuster. Marked xfail so CI is green; pop entries as they get
 # fixed so the underlying blocking call is gone for good.
-_KNOWN_BLOCKING: frozenset[str] = frozenset(
-    {
-        "tests/test_api.py::test_authenticate_with_session_storage",
-        "tests/test_api.py::test_clear_all_sessions_handles_file_disappearing",
-        "tests/test_api.py::test_clear_all_sessions_removes_file",
-        "tests/test_api.py::test_clear_methods_do_nothing_when_sessions_disabled[clear_all_sessions]",
-        "tests/test_api.py::test_clear_methods_do_nothing_when_sessions_disabled[clear_session]",
-        "tests/test_api.py::test_clear_methods_handle_missing_file[clear_all_sessions]",
-        "tests/test_api.py::test_clear_methods_handle_missing_file[clear_session]",
-        "tests/test_api.py::test_clear_session_removes_specific_session",
-        "tests/test_api.py::test_clear_session_when_session_not_in_config",
-        "tests/test_api.py::test_clear_session_with_invalid_config_file",
-        "tests/test_api.py::test_get_camera_video",
-        "tests/test_api.py::test_invalid_token_triggers_reauthentication",
-        "tests/test_api.py::test_load_session_accepts_valid_csrf_token",
-        "tests/test_api.py::test_load_session_rejects_missing_csrf_token",
-        "tests/test_api.py::test_load_session_with_invalid_token",
-        "tests/test_api.py::test_load_session_with_token_two_segments",
-        "tests/test_utils.py::test_write_json",
-    }
-)
+_KNOWN_BLOCKING: frozenset[str] = frozenset()
 
 
 def pytest_collection_modifyitems(
@@ -148,6 +129,30 @@ for _ext in ("png", "mp4"):
     for _path in SAMPLE_DATA_DIRECTORY.glob(f"*.{_ext}"):
         _read_binary_file_cached(_path.stem, _ext)
 CONSTANTS.data()  # force the sample_constants.json read out of any loop
+
+
+async def async_write_bytes(path: Path, data: bytes) -> None:
+    """Write ``data`` to ``path`` without blocking the event loop."""
+    async with aiofiles.open(path, "wb") as f:
+        await f.write(data)
+
+
+async def async_read_bytes(path: Path) -> bytes:
+    """Read ``path`` as bytes without blocking the event loop."""
+    async with aiofiles.open(path, "rb") as f:
+        return await f.read()
+
+
+async def async_write_text(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` without blocking the event loop."""
+    async with aiofiles.open(path, "w") as f:
+        await f.write(text)
+
+
+async def async_read_text(path: Path) -> str:
+    """Read ``path`` as text without blocking the event loop."""
+    async with aiofiles.open(path) as f:
+        return await f.read()
 
 
 def read_bootstrap_json_file():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import aiohttp
 import orjson
 import pytest
+from aiofiles import os as aos
 from PIL import Image
 
 from tests.conftest import (
@@ -31,6 +32,9 @@ from tests.conftest import (
     TEST_VIDEO_EXISTS,
     TEST_VIEWPORT_EXISTS,
     MockDatetime,
+    async_read_bytes,
+    async_write_bytes,
+    async_write_text,
     compare_objs,
     get_time,
     validate_video_file,
@@ -1093,7 +1097,7 @@ async def test_get_package_camera_snapshot_args(protect_client: ProtectApiClient
 @patch("uiprotect.api.datetime", MockDatetime)
 @patch("uiprotect.api.time.time", get_time)
 @pytest.mark.asyncio()
-async def test_get_camera_video(protect_client: ProtectApiClient, now, tmp_binary_file):
+async def test_get_camera_video(protect_client: ProtectApiClient, now, tmp_path: Path):
     camera = next(iter(protect_client.bootstrap.cameras.values()))
     start = now - timedelta(seconds=CONSTANTS["camera_video_length"])
 
@@ -1111,10 +1115,11 @@ async def test_get_camera_video(protect_client: ProtectApiClient, now, tmp_binar
         raise_exception=False,
     )
 
-    tmp_binary_file.write(data)
-    tmp_binary_file.close()
-
-    validate_video_file(tmp_binary_file.name, CONSTANTS["camera_video_length"])
+    out_path = tmp_path / "video.mp4"
+    await async_write_bytes(out_path, data)
+    await asyncio.to_thread(
+        validate_video_file, out_path, CONSTANTS["camera_video_length"]
+    )
 
 
 @pytest.mark.asyncio()
@@ -1738,7 +1743,7 @@ async def test_load_session_rejects_missing_csrf_token(tmp_path: Path) -> None:
     }
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps(config))
+    await async_write_bytes(config_file, orjson.dumps(config))
 
     # Try to load the session
     cookie = await client._read_auth_config()
@@ -1775,7 +1780,7 @@ async def test_load_session_accepts_valid_csrf_token(tmp_path: Path) -> None:
     }
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps(config))
+    await async_write_bytes(config_file, orjson.dumps(config))
 
     # Try to load the session
     cookie = await client._read_auth_config()
@@ -1815,7 +1820,7 @@ async def test_load_session_with_invalid_token(tmp_path: Path) -> None:
     }
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps(config))
+    await async_write_bytes(config_file, orjson.dumps(config))
 
     # Load the session
     cookie = await client._read_auth_config()
@@ -1861,7 +1866,7 @@ async def test_load_session_with_token_two_segments(tmp_path: Path) -> None:
     }
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps(config))
+    await async_write_bytes(config_file, orjson.dumps(config))
 
     # Load the session
     cookie = await client._read_auth_config()
@@ -1899,7 +1904,7 @@ async def test_invalid_token_triggers_reauthentication(
     }
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps(invalid_config))
+    await async_write_bytes(config_file, orjson.dumps(invalid_config))
 
     # Setup mock for authentication
     mock_auth_response = AsyncMock()
@@ -1929,7 +1934,7 @@ async def test_invalid_token_triggers_reauthentication(
     assert client._is_authenticated is True
 
     # Verify the session file was updated with the new valid token
-    updated_config = orjson.loads(config_file.read_bytes())
+    updated_config = orjson.loads(await async_read_bytes(config_file))
     session_data = updated_config["sessions"][session_hash]
     assert session_data["csrf"] == "new-csrf-token-12345"
     # The new token should be a valid JWT format (3 segments)
@@ -1968,12 +1973,12 @@ async def test_clear_session_removes_specific_session(tmp_path: Path) -> None:
     }
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps(config))
+    await async_write_bytes(config_file, orjson.dumps(config))
 
     await client.clear_session()
 
     # File should still exist with the other session intact
-    updated_config = orjson.loads(config_file.read_bytes())
+    updated_config = orjson.loads(await async_read_bytes(config_file))
     assert session_hash not in updated_config["sessions"]
     assert "other_session_hash" in updated_config["sessions"]
     assert client._is_authenticated is False
@@ -2013,11 +2018,11 @@ async def test_clear_all_sessions_removes_file(
     }
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps(config))
+    await async_write_bytes(config_file, orjson.dumps(config))
 
     await client.clear_all_sessions()
 
-    assert not config_file.exists()
+    assert not await aos.path.exists(config_file)
     assert client._is_authenticated is False
     assert client._last_token_cookie is None
     assert client._last_token_cookie_decode is None
@@ -2041,13 +2046,13 @@ async def test_clear_methods_do_nothing_when_sessions_disabled(
     )
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps({"sessions": {}}))
+    await async_write_bytes(config_file, orjson.dumps({"sessions": {}}))
 
     await getattr(client, clear_method)()
 
     # File should still exist since sessions are disabled
-    assert config_file.exists()
-    config = orjson.loads(config_file.read_bytes())
+    assert await aos.path.exists(config_file)
+    config = orjson.loads(await async_read_bytes(config_file))
     assert config == {"sessions": {}}
 
 
@@ -2066,13 +2071,13 @@ async def test_clear_session_with_invalid_config_file(tmp_path: Path) -> None:
 
     # Create a config file with invalid JSON
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_text("invalid json content {{{")
+    await async_write_text(config_file, "invalid json content {{{")
 
     # Call clear_session - should handle the exception gracefully
     await client.clear_session()
 
     # File should still exist
-    assert config_file.exists()
+    assert await aos.path.exists(config_file)
 
 
 @pytest.mark.asyncio()
@@ -2099,7 +2104,7 @@ async def test_clear_methods_handle_missing_file(
 
     # No file should exist and no error should be raised
     config_file = tmp_path / "unifi_protect.json"
-    assert not config_file.exists()
+    assert not await aos.path.exists(config_file)
     # Client state should NOT be reset since no file was found
     assert client._is_authenticated is True
     assert client._last_token_cookie == "some_token"  # noqa: S105
@@ -2133,12 +2138,12 @@ async def test_clear_session_when_session_not_in_config(tmp_path: Path) -> None:
     }
 
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps(config))
+    await async_write_bytes(config_file, orjson.dumps(config))
 
     await client.clear_session()
 
     # File should still have the original session
-    updated_config = orjson.loads(config_file.read_bytes())
+    updated_config = orjson.loads(await async_read_bytes(config_file))
     assert "different_hash" in updated_config["sessions"]
     # Client state should NOT be reset since no session was actually removed
     assert client._is_authenticated is True
@@ -2166,7 +2171,7 @@ async def test_clear_all_sessions_handles_file_disappearing(
 
     # Create config file so path.exists() check passes
     config_file = tmp_path / "unifi_protect.json"
-    config_file.write_bytes(orjson.dumps({"sessions": {}}))
+    await async_write_bytes(config_file, orjson.dumps({"sessions": {}}))
 
     # Mock aos.remove to raise FileNotFoundError (race condition simulation)
     mock_remove.side_effect = FileNotFoundError(
@@ -2217,9 +2222,9 @@ async def test_authenticate_with_session_storage(
 
     # Verify session was saved to file
     config_file = tmp_path / "unifi_protect.json"
-    assert config_file.exists()
+    assert await aos.path.exists(config_file)
 
-    config = orjson.loads(config_file.read_bytes())
+    config = orjson.loads(await async_read_bytes(config_file))
     assert "sessions" in config
     sessions = config["sessions"]
     assert len(sessions) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,9 +14,11 @@ from uuid import UUID
 
 import jwt
 import pytest
+from aiofiles import os as aos
 from pydantic.fields import FieldInfo
 
 import uiprotect.utils as utils_module
+from tests.conftest import async_read_text
 from uiprotect.data import EventType
 from uiprotect.data.bootstrap import WSStat
 from uiprotect.data.types import (
@@ -700,8 +702,8 @@ def test_print_ws_stat_summary():
 async def test_write_json(tmp_path: Path):
     path = tmp_path / "test.json"
     await write_json(path, {"key": "value"})
-    assert path.exists()
-    assert '"key": "value"' in path.read_text()
+    assert await aos.path.exists(path)
+    assert '"key": "value"' in await async_read_text(path)
 
 
 # --- log_event tests ---


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Drains the `_KNOWN_BLOCKING` xfail list from the blockbuster PR by porting the 17 remaining tests off sync IO. The session and CSRF tests in `tests/test_api.py` now write and read their config files via small `async_write_bytes`/`async_read_bytes`/`async_write_text`/`async_read_text` helpers added to `tests/conftest.py` (thin aiofiles wrappers), and `path.exists` checks switch to `aiofiles.os.path.exists`; `test_get_camera_video` swaps the `NamedTemporaryFile` write for `aiofiles` into a `tmp_path` and runs the PyAV validate through `asyncio.to_thread`; `test_write_json` follows the same pattern.

After this `_KNOWN_BLOCKING` is empty, the autouse blockbuster fixture passes for the whole suite, and `pre-commit run -a` is clean.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test infrastructure updated to use asynchronous file operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uilibs/uiprotect/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->