### PR TITLE
chore(devcontainer): persist credentials across rebuilds and speed up image builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,15 @@
         "target": "devcontainer"
     },
     "updateRemoteUserUID": true,
-    "features": {},
-    "postCreateCommand": "bash -c 'export LANG=C.UTF-8 LC_ALL=C.UTF-8 && poetry install --with dev --no-interaction --no-ansi && LANG=C.UTF-8 LC_ALL=C.UTF-8 poetry run pre-commit install --install-hooks && echo \"LANG=C.UTF-8\" >> /etc/environment && echo \"LC_ALL=C.UTF-8\" >> /etc/environment'",
+    "features": {
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+    },
+    "initializeCommand": "touch ~/.gitconfig",
+    "postCreateCommand": "poetry install --no-interaction --no-ansi && poetry run pre-commit install --install-hooks",
+    "mounts": [
+        "source=${localEnv:HOME}/.claude,target=/root/.claude,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached"
+    ],
     "remoteUser": "root",
     "containerEnv": {
         "GIT_AUTHOR_NAME": "${localEnv:GIT_AUTHOR_NAME:${localEnv:USER:devcontainer}}",
@@ -16,8 +23,8 @@
         "GIT_COMMITTER_EMAIL": "${localEnv:GIT_COMMITTER_EMAIL:${localEnv:USER:devcontainer}@localhost}"
     },
     "remoteEnv": {
-        "LANG": "C.UTF-8",
-        "LC_ALL": "C.UTF-8"
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8"
     },
     "customizations": {
         "vscode": {
@@ -67,7 +74,10 @@
                 "esbenp.prettier-vscode",
                 "ms-python.mypy-type-checker",
                 "ms-vscode.test-adapter-converter",
-                "littlefoxteam.vscode-python-test-adapter"
+                "littlefoxteam.vscode-python-test-adapter",
+                "GitHub.vscode-pull-request-github",
+                "usernamehw.errorlens",
+                "anthropic.claude-code"
             ]
         }
     }

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,23 +91,22 @@ WORKDIR /workspaces/uiprotect/
 
 FROM python:3.13-slim-bookworm AS devcontainer
 
-RUN apt-get update && apt-get install -y \
-    curl \
-    git \
-    build-essential \
-    bash \
-    locales \
+ARG TARGETPLATFORM
+
+RUN --mount=type=cache,mode=0755,id=apt-$TARGETPLATFORM,target=/var/lib/apt/lists \
+    apt-get update -qq \
+    && apt-get install -yqq curl git build-essential bash locales \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
-    && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
-    && rm -rf /var/lib/apt/lists/*
+    && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
 SHELL ["/bin/bash", "-c"]
 
-RUN curl -sSL https://install.python-poetry.org | POETRY_VERSION=2.2.1 python3 -
+RUN --mount=type=cache,mode=0755,id=pip-$TARGETPLATFORM,target=/root/.cache \
+    curl -sSL https://install.python-poetry.org | POETRY_VERSION=2.2.1 python3 -
 
 ENV PATH="/root/.local/bin:${PATH}"
 
@@ -116,4 +115,5 @@ WORKDIR /workspace
 ENV POETRY_VIRTUALENVS_CREATE=false
 
 COPY pyproject.toml poetry.lock* ./
-RUN poetry install --no-root
+RUN --mount=type=cache,mode=0755,id=pip-$TARGETPLATFORM,target=/root/.cache \
+    poetry install --with dev --no-root


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
- mount ~/.claude and ~/.gitconfig from host to survive container rebuilds
- add initializeCommand to ensure ~/.gitconfig exists before mount
- move dev dependencies into Dockerfile build stage to reduce postCreateCommand runtime
- add BuildKit cache mounts for apt and pip in devcontainer stage
- simplify postCreateCommand (no longer needs to install dev deps or manipulate locale)
- align locale to en_US.UTF-8 consistently across Dockerfile and devcontainer.json
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development container configuration with enhanced build caching for faster setup.
  * Integrated GitHub CLI into the development environment.
  * Optimized dependency installation and locale settings for development workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uilibs/uiprotect/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->