### PR TITLE
ci: skip release dry-run on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,6 @@ jobs:
     needs:
       - test
       - lint
-    # Skip the dry-run on fork PRs: the branch lives in the fork so the
-    # checkout below cannot resolve it, and PSR can't push tags from a fork
-    # anyway.  Push-to-main runs are always included.
-    if: |
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     # Only enter the protected 'release' environment when actually releasing
@@ -143,11 +137,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
+          # Use the merge commit ref so fork-PR branches (which only exist in
+          # the contributor's fork) don't cause a 404.  PSR needs a branch
+          # name, so we recreate one locally in the next step.
+          ref: ${{ github.ref }}
           # Fall back to GITHUB_TOKEN on dependabot PRs, where
           # secrets.BOT_ACCESS_TOKEN is not exposed and would otherwise
           # leave actions/checkout's `token` input empty.
           token: ${{ secrets.BOT_ACCESS_TOKEN || github.token }}
+
+      - name: Create local branch
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git switch -C "$BRANCH"
 
       - name: Setup Git
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,12 @@ jobs:
     needs:
       - test
       - lint
+    # Skip the dry-run on fork PRs: the branch lives in the fork so the
+    # checkout below cannot resolve it, and PSR can't push tags from a fork
+    # anyway.  Push-to-main runs are always included.
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     # Only enter the protected 'release' environment when actually releasing


### PR DESCRIPTION
## Description of change

The `release` job checks out the PR head branch by name via `ref: ${{ github.head_ref }}`. When a PR comes from a fork (e.g. `bluetoothbot/uiprotect`), that branch only exists in the fork — looking it up in `uilibs/uiprotect` returns a 404 and the job fails before `python-semantic-release` even runs.

Seen in: https://github.com/uilibs/uiprotect/actions/runs/26412108182/job/77749561930 (PR #864)

The dry-run adds no value for fork PRs anyway: PSR cannot push tags or commits without write access to the base repo, so skipping the job on fork PRs is correct behaviour.

## Changes

- `.github/workflows/ci.yml`: add `if` condition to the `release` job that skips it when the PR head is in a different repository. Push-to-main runs are always included.

## Checklist

- [x] I have followed the contribution guidelines
- [x] Tests added/updated — N/A (CI config change)
- [x] Documentation updated — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI release workflow to use the repository ref for checkout during release jobs.
  * Added a step that creates/recreates a local branch from the PR/ref name so the release flow always has a valid branch context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uilibs/uiprotect/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->