### PR TITLE
fix: poll events during bootstrap to allow package events to be emitted

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -1402,6 +1402,11 @@ class ProtectApiClient(BaseApiClient):
             self.__dict__.pop("bootstrap", None)
             self._bootstrap = bootstrap
 
+            try:
+                await self.poll_events()
+            except Exception as err:
+                _LOGGER.debug("Failed to poll events after bootstrap: %s", err)
+
             # Set connection host if not set via override_connection_host
             if self._connection_host is None:
                 await self._async_set_connection_host_from_bootstrap(bootstrap)

--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -1404,8 +1404,15 @@ class ProtectApiClient(BaseApiClient):
 
             try:
                 await self.poll_events()
-            except Exception as err:
+            except (
+                BadRequest,
+                NotAuthorized,
+                NvrError,
+                GlobalAlarmManagerError,
+            ) as err:
                 _LOGGER.debug("Failed to poll events after bootstrap: %s", err)
+            except Exception:
+                _LOGGER.exception("Failed to poll events after bootstrap")
 
             # Set connection host if not set via override_connection_host
             if self._connection_host is None:

--- a/src/uiprotect/data/base.py
+++ b/src/uiprotect/data/base.py
@@ -875,6 +875,8 @@ class BluetoothConnectionState(WirelessConnectionState):
 
 
 class WifiConnectionState(WirelessConnectionState):
+    model_config = ConfigDict(coerce_numbers_to_str=True)
+
     phy_rate: float | None = None
     channel: int | None = None
     frequency: int | None = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -570,7 +570,7 @@ async def test_force_update_with_nfc_fingerprint_version(
         ) as get_bootstrap_mock,
         patch(
             "uiprotect.api.ProtectApiClient.api_request_list",
-            side_effect=lambda endpoint: {
+            side_effect=lambda endpoint, **kwargs: {
                 "keyrings": [
                     {
                         "deviceType": "camera",
@@ -604,7 +604,7 @@ async def test_force_update_with_nfc_fingerprint_version(
         assert api_request_list_mock.called
         api_request_list_mock.assert_any_call("keyrings")
         api_request_list_mock.assert_any_call("ulp-users")
-        assert api_request_list_mock.call_count == 2
+        assert api_request_list_mock.call_count == 3
 
     assert protect_client.bootstrap
     assert original_bootstrap != protect_client.bootstrap
@@ -638,7 +638,7 @@ async def test_force_update_no_user_keyring_access(protect_client: ProtectApiCli
         assert api_request_list_mock.called
         api_request_list_mock.assert_any_call("keyrings")
         api_request_list_mock.assert_any_call("ulp-users")
-        assert api_request_list_mock.call_count == 2
+        assert api_request_list_mock.call_count == 3
 
     assert protect_client.bootstrap
     assert original_bootstrap != protect_client.bootstrap

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -648,6 +648,30 @@ async def test_force_update_no_user_keyring_access(protect_client: ProtectApiCli
 
 
 @pytest.mark.asyncio()
+async def test_poll_events_known_error_during_update(protect_client: ProtectApiClient):
+    protect_client._bootstrap = None
+    with patch(
+        "uiprotect.api.ProtectApiClient.poll_events",
+        side_effect=NvrError("connection failed"),
+    ):
+        bootstrap = await protect_client.update()
+    assert bootstrap is not None
+
+
+@pytest.mark.asyncio()
+async def test_poll_events_unexpected_error_during_update(
+    protect_client: ProtectApiClient,
+):
+    protect_client._bootstrap = None
+    with patch(
+        "uiprotect.api.ProtectApiClient.poll_events",
+        side_effect=RuntimeError("unexpected"),
+    ):
+        bootstrap = await protect_client.update()
+    assert bootstrap is not None
+
+
+@pytest.mark.asyncio()
 async def test_force_update_user_keyring_internal_error(
     protect_client: ProtectApiClient,
 ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,6 +50,7 @@ from uiprotect.data import (
     PTZPreset,
     create_from_unifi_dict,
 )
+from uiprotect.data.base import WifiConnectionState
 from uiprotect.data.devices import LEDSettings
 from uiprotect.data.types import Version, VideoMode
 from uiprotect.exceptions import (
@@ -4011,3 +4012,10 @@ async def test_create_talkback_session_public(protect_client: ProtectApiClient):
         method="post",
         public_api=True,
     )
+
+
+def test_wifi_connection_state_coerces_int_experience():
+    """Integer experience values from the server are coerced to str."""
+    state = WifiConnectionState(experience=100)
+    assert state.experience == "100"
+    assert isinstance(state.experience, str)

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -19,7 +19,7 @@ from tests.conftest import (
     MockDatetime,
     MockWebsocket,
 )
-from uiprotect.data import EventType, WSPacket
+from uiprotect.data import Event, EventType, WSPacket
 from uiprotect.data.base import ProtectModel
 from uiprotect.data.devices import EVENT_PING_INTERVAL, Camera
 from uiprotect.data.types import ModelType
@@ -569,6 +569,70 @@ async def test_ws_event_update(
     bootstrap = protect_client.bootstrap.unifi_dict()
 
     assert bootstrap == bootstrap_before
+
+
+@pytest.mark.asyncio()
+@patch("uiprotect.api.datetime", MockDatetime)
+async def test_ws_event_update_in_flight(
+    protect_client_no_debug: ProtectApiClient,
+    now,
+    camera,
+    packet: WSPacket,
+):
+    """Update packets for events active before WS connect are emitted after seeding via poll_events."""
+    protect_client = protect_client_no_debug
+    camera_id = camera["id"]
+    event_id = "46f37803-d601-4eff-a887-6717460db4f1"
+    expected_updated_id = "d7d12bff-a14a-415b-a7ba-cd2d6a7115ca"
+    start_ms = to_js_time(now - timedelta(seconds=6))
+    end_ms = to_js_time(now)
+
+    seed = Event.from_unifi_dict(
+        api=protect_client,
+        id=event_id,
+        type="smartDetectZone",
+        start=start_ms,
+        score=0,
+        smartDetectTypes=["package"],
+        smartDetectEvents=[],
+        camera=camera_id,
+        partition=None,
+        user=None,
+        metadata={},
+        thumbnail=f"e-{event_id}",
+        heatmap=f"e-{event_id}",
+        modelKey="event",
+    )
+    protect_client.bootstrap.process_event(seed)
+
+    action_frame: WSJSONPacketFrame = packet.action_frame  # type: ignore[assignment]
+    action_frame.data = {
+        "action": "update",
+        "id": event_id,
+        "modelKey": "event",
+        "newUpdateId": expected_updated_id,
+    }
+
+    data_frame: WSJSONPacketFrame = packet.data_frame  # type: ignore[assignment]
+    data_frame.data = {
+        "end": end_ms,
+        "smartDetectTypes": ["package"],
+        "score": 0,
+        "modelKey": "event",
+    }
+
+    received: list[WSSubscriptionMessage] = []
+    protect_client.subscribe_websocket(received.append)
+
+    msg = MagicMock()
+    msg.data = packet.pack_frames()
+    protect_client._process_ws_message(msg)
+
+    assert len(received) == 1
+    assert received[0].action == WSAction.UPDATE
+    assert received[0].new_obj is not None
+    assert received[0].new_obj.id == event_id
+    assert protect_client.bootstrap.events[event_id].end is not None
 
 
 @pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Mostly relates to https://github.com/home-assistant/core/issues/170153 (I can't find a related issue raised in this protect's repo). Having experienced myself that since Unifi Protect was updated to 7.x, package notifications stopped working. It turns out that the UFP is indeed sending the event, but this package is discarding it entirely, with an error `Unknown model type: smartDetectObject`.

In bootstrap.py:629-631, there's a check that populates `devices` from `self.events`. `self.events` is always empty, because `poll_events()` is never called. On line 631, `action_id` will never be in `devices` (aka `self.events`). The simple solution was to call `poll_events()` once on startup (though for some reason it does end up calling the API twice for reasons I can't fathom). But this does end up causing the package event to be emitted, HA receives the event and reacts to it.

Also fixed a data serialization error in `WifiConnectionState` where `experience` is sent as an integer. Pydantic by default won't coerce integers to strings without being explicitly told to do so.

Tested on HA 2026.5.4.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event polling failures no longer interrupt the bootstrap update process; failures are now logged and handled gracefully.
  * WiFi connection state now properly handles numeric input values, automatically converting them to the expected string format.

* **Tests**
  * Enhanced test coverage for event polling during bootstrap updates and websocket event delivery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uilibs/uiprotect/pull/875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->