### PR TITLE
feat(public-api): add typed alarm hub accessors to LinkStation

### DIFF
--- a/src/uiprotect/data/__init__.py
+++ b/src/uiprotect/data/__init__.py
@@ -33,6 +33,10 @@ from .nvr import (
 )
 from .public_bootstrap import PublicBootstrap
 from .public_devices import (
+    AlarmHubBattery,
+    AlarmHubCover,
+    AlarmHubInput,
+    AlarmHubOutput,
     ArmProfile,
     Fob,
     LinkStation,
@@ -73,6 +77,7 @@ from .types import (
     DEFAULT,
     DEFAULT_TYPE,
     PTZ_HOME_SLOT,
+    AlarmHubInputType,
     AnalyticsOption,
     AudioStyle,
     ChimeType,
@@ -142,6 +147,11 @@ __all__ = [
     "PTZ_HOME_SLOT",
     "WS_HEADER_SIZE",
     "AiPort",
+    "AlarmHubBattery",
+    "AlarmHubCover",
+    "AlarmHubInput",
+    "AlarmHubInputType",
+    "AlarmHubOutput",
     "AnalyticsOption",
     "ArmProfile",
     "AudioStyle",

--- a/src/uiprotect/data/public_devices.py
+++ b/src/uiprotect/data/public_devices.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict
 from ..exceptions import BadRequest
 from .base import ProtectBaseObject, ProtectModelWithId
 from .types import (
+    AlarmHubInputType,
     DeviceState,
     FobAwayState,
     FobButton,
@@ -398,6 +399,62 @@ class Speaker(ProtectModelWithId):
 # ---------------------------------------------------------------------------
 
 
+# The full ``alarmHub`` payload is kept as an opaque dict on
+# :attr:`LinkStation.alarm_hub` because its low-level electrical maps use keys
+# that are not valid Python identifiers (``"12v"``, ``"+"``, ``"-"``). The
+# sub-models below type only the useful, well-formed slice of that payload and
+# are surfaced through read-only accessors that parse the raw dict on demand —
+# leaving the opaque dict (and any unmodeled / future keys) untouched.
+
+
+class AlarmHubBattery(ProtectBaseObject):
+    """Backup battery status of an alarm hub (``alarmHub.battery``)."""
+
+    # Typed as ``str`` (not an enum) so unknown server values don't raise.
+    battery_status: str | None = None
+    connection: str | None = None
+    voltage: float | None = None
+
+
+class AlarmHubCover(ProtectBaseObject):
+    """Tamper cover status of an alarm hub (``alarmHub.cover``)."""
+
+    # ``"open"`` / ``"close"`` on the wire; ``str`` for forward-compatibility.
+    status: str | None = None
+    distance: int | None = None
+
+
+class AlarmHubInput(ProtectBaseObject):
+    """
+    A single wired input (zone) on an alarm hub (``alarmHub.input[n]``).
+
+    Unused terminals carry only ``enable`` / ``type`` / ``status``; configured
+    zones additionally carry a ``name``, an :class:`AlarmHubInputType`, the last
+    trigger time and an optional linked camera.
+    """
+
+    # ``"on"`` / ``"off"``; ``"no"`` (normally-open) / ``"nc"`` (normally-closed);
+    # ``"normal"`` when idle. Kept as ``str`` for forward-compatibility.
+    enable: str | None = None
+    type: str | None = None
+    status: str | None = None
+    name: str | None = None
+    input_type: AlarmHubInputType | None = None
+    last_triggered_at: int | None = None
+    camera_id: str | None = None
+
+
+class AlarmHubOutput(ProtectBaseObject):
+    """A single output channel on an alarm hub (``alarmHub.output[n]``)."""
+
+    # ``"on"`` / ``"off"`` for ``active`` / ``enable``; ``"dry"`` etc. for status.
+    active: str | None = None
+    enable: str | None = None
+    status: str | None = None
+    delay: int | None = None
+    duration: int | None = None
+
+
 class LinkStation(ProtectModelWithId):
     """
     Public API link station / alarm hub.
@@ -453,6 +510,47 @@ class LinkStation(ProtectModelWithId):
             delay=delay,
             duration=duration,
         )
+
+    # -- Typed accessors over the opaque ``alarm_hub`` payload --------------
+    #
+    # These parse the raw dict on demand. They return ``None`` / ``{}`` when
+    # this is not an alarm hub (``alarm_hub is None``) or when the relevant key
+    # is absent, so callers never need to guard against the opaque shape.
+
+    @property
+    def alarm_hub_armed(self) -> str | None:
+        """Overall armed state of the hub (``"on"`` / ``"off"``), if present."""
+        if not self.alarm_hub:
+            return None
+        return self.alarm_hub.get("armed")
+
+    @property
+    def alarm_hub_battery(self) -> AlarmHubBattery | None:
+        """Backup-battery status, or ``None`` if not reported."""
+        if not self.alarm_hub or (raw := self.alarm_hub.get("battery")) is None:
+            return None
+        return AlarmHubBattery.from_unifi_dict(**raw)
+
+    @property
+    def alarm_hub_cover(self) -> AlarmHubCover | None:
+        """Tamper-cover status, or ``None`` if not reported."""
+        if not self.alarm_hub or (raw := self.alarm_hub.get("cover")) is None:
+            return None
+        return AlarmHubCover.from_unifi_dict(**raw)
+
+    @property
+    def alarm_hub_inputs(self) -> dict[int, AlarmHubInput]:
+        """Wired inputs (zones) keyed by their integer terminal index."""
+        if not self.alarm_hub or (raw := self.alarm_hub.get("input")) is None:
+            return {}
+        return {int(k): AlarmHubInput.from_unifi_dict(**v) for k, v in raw.items()}
+
+    @property
+    def alarm_hub_outputs(self) -> dict[int, AlarmHubOutput]:
+        """Output channels keyed by their integer terminal index."""
+        if not self.alarm_hub or (raw := self.alarm_hub.get("output")) is None:
+            return {}
+        return {int(k): AlarmHubOutput.from_unifi_dict(**v) for k, v in raw.items()}
 
 
 # ---------------------------------------------------------------------------

--- a/src/uiprotect/data/public_devices.py
+++ b/src/uiprotect/data/public_devices.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from functools import cache
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar
 
 from ..exceptions import BadRequest
 from .base import ProtectBaseObject, ProtectModelWithId
@@ -455,6 +455,29 @@ class AlarmHubOutput(ProtectBaseObject):
     duration: int | None = None
 
 
+_AlarmHubChannelT = TypeVar("_AlarmHubChannelT", bound=ProtectBaseObject)
+
+
+def _parse_indexed_channels(
+    raw: dict[str, Any],
+    klass: type[_AlarmHubChannelT],
+) -> dict[int, _AlarmHubChannelT]:
+    """
+    Parse an integer-indexed alarm-hub channel map (``input`` / ``output``).
+
+    Entries whose key is not an integer are skipped rather than raising, so a
+    non-numeric key added by future firmware can't break the whole accessor.
+    """
+    channels: dict[int, _AlarmHubChannelT] = {}
+    for key, value in raw.items():
+        try:
+            index = int(key)
+        except (TypeError, ValueError):
+            continue
+        channels[index] = klass.from_unifi_dict(**value)
+    return channels
+
+
 class LinkStation(ProtectModelWithId):
     """
     Public API link station / alarm hub.
@@ -514,8 +537,8 @@ class LinkStation(ProtectModelWithId):
     # -- Typed accessors over the opaque ``alarm_hub`` payload --------------
     #
     # These parse the raw dict on demand. They return ``None`` / ``{}`` when
-    # this is not an alarm hub (``alarm_hub is None``) or when the relevant key
-    # is absent, so callers never need to guard against the opaque shape.
+    # this is not an alarm hub or when the relevant section is absent or empty,
+    # so callers never need to guard against the opaque shape.
 
     @property
     def alarm_hub_armed(self) -> str | None:
@@ -527,30 +550,30 @@ class LinkStation(ProtectModelWithId):
     @property
     def alarm_hub_battery(self) -> AlarmHubBattery | None:
         """Backup-battery status, or ``None`` if not reported."""
-        if not self.alarm_hub or (raw := self.alarm_hub.get("battery")) is None:
+        if not self.alarm_hub or not (raw := self.alarm_hub.get("battery")):
             return None
         return AlarmHubBattery.from_unifi_dict(**raw)
 
     @property
     def alarm_hub_cover(self) -> AlarmHubCover | None:
         """Tamper-cover status, or ``None`` if not reported."""
-        if not self.alarm_hub or (raw := self.alarm_hub.get("cover")) is None:
+        if not self.alarm_hub or not (raw := self.alarm_hub.get("cover")):
             return None
         return AlarmHubCover.from_unifi_dict(**raw)
 
     @property
     def alarm_hub_inputs(self) -> dict[int, AlarmHubInput]:
         """Wired inputs (zones) keyed by their integer terminal index."""
-        if not self.alarm_hub or (raw := self.alarm_hub.get("input")) is None:
+        if not self.alarm_hub or not (raw := self.alarm_hub.get("input")):
             return {}
-        return {int(k): AlarmHubInput.from_unifi_dict(**v) for k, v in raw.items()}
+        return _parse_indexed_channels(raw, AlarmHubInput)
 
     @property
     def alarm_hub_outputs(self) -> dict[int, AlarmHubOutput]:
         """Output channels keyed by their integer terminal index."""
-        if not self.alarm_hub or (raw := self.alarm_hub.get("output")) is None:
+        if not self.alarm_hub or not (raw := self.alarm_hub.get("output")):
             return {}
-        return {int(k): AlarmHubOutput.from_unifi_dict(**v) for k, v in raw.items()}
+        return _parse_indexed_channels(raw, AlarmHubOutput)
 
 
 # ---------------------------------------------------------------------------

--- a/src/uiprotect/data/types.py
+++ b/src/uiprotect/data/types.py
@@ -665,6 +665,21 @@ class NvrArmModeStatus(UnknownValuesEnumMixin, enum.StrEnum):
 
 
 @enum.unique
+class AlarmHubInputType(UnknownValuesEnumMixin, enum.StrEnum):
+    """
+    Kind of wired zone connected to an alarm-hub input (``inputType`` field).
+
+    Only populated for configured inputs; absent on unused terminals. Unknown
+    values (future firmware) coerce to :attr:`UNKNOWN` rather than raising.
+    """
+
+    MOTION = "MOTION"
+    ENTRY = "ENTRY"
+    EMERGENCY_BUTTON = "EMERGENCY_BUTTON"
+    UNKNOWN = "unknown"
+
+
+@enum.unique
 class RelayOutputState(UnknownValuesEnumMixin, enum.StrEnum):
     """State of a single relay output channel (``state`` field)."""
 

--- a/tests/test_alarm_hub.py
+++ b/tests/test_alarm_hub.py
@@ -225,14 +225,36 @@ def test_link_station_accessors_are_empty_when_not_hub() -> None:
     assert ls.alarm_hub_outputs == {}
 
 
-def test_alarm_hub_accessors_with_missing_keys() -> None:
-    # Hub present, but a sparse payload (e.g. older firmware) omits sections.
+@pytest.mark.parametrize(
+    "alarm_hub",
+    [
+        pytest.param({}, id="absent"),
+        # Empty objects must read the same as absent ("no meaningful data").
+        pytest.param(
+            {"battery": {}, "cover": {}, "input": {}, "output": {}}, id="empty"
+        ),
+    ],
+)
+def test_alarm_hub_accessors_when_sections_empty(alarm_hub: dict[str, Any]) -> None:
     fixture = deepcopy(_LINK_STATION_FIXTURE)
     fixture["isAlarmHub"] = True
-    fixture["alarmHub"] = {}
+    fixture["alarmHub"] = alarm_hub
     hub = LinkStation.from_unifi_dict(**fixture)
     assert hub.alarm_hub_armed is None
     assert hub.alarm_hub_battery is None
     assert hub.alarm_hub_cover is None
     assert hub.alarm_hub_inputs == {}
     assert hub.alarm_hub_outputs == {}
+
+
+def test_alarm_hub_non_integer_channel_keys_are_skipped() -> None:
+    # Forward-compat: a non-numeric key must be skipped, not raise.
+    fixture = deepcopy(_LINK_STATION_FIXTURE)
+    fixture["isAlarmHub"] = True
+    fixture["alarmHub"] = {
+        "input": {"0": {"type": "no"}, "meta": {"type": "no"}},
+        "output": {"1": {"status": "dry"}, "summary": {"status": "dry"}},
+    }
+    hub = LinkStation.from_unifi_dict(**fixture)
+    assert set(hub.alarm_hub_inputs) == {0}
+    assert set(hub.alarm_hub_outputs) == {1}

--- a/tests/test_alarm_hub.py
+++ b/tests/test_alarm_hub.py
@@ -1,0 +1,238 @@
+"""
+Tests for the typed Alarm Hub accessors on :class:`LinkStation`.
+
+The ``alarmHub`` payload is intentionally stored as an opaque ``dict`` on
+:attr:`LinkStation.alarm_hub` (its low-level electrical maps use keys such as
+``"12v"``/``"+"``/``"-"`` that are not valid Python identifiers).  These tests
+cover the *additive* typed accessors that parse the useful, well-formed slice
+of that payload (armed state, battery, tamper cover, wired inputs/zones and
+outputs) on demand, without disturbing the raw dict.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from uiprotect.data import (
+    AlarmHubBattery,
+    AlarmHubCover,
+    AlarmHubInput,
+    AlarmHubInputType,
+    AlarmHubOutput,
+    LinkStation,
+)
+
+ALARM_HUB_ID = "66d025b301ebc903e80003f0"
+
+# Real-shaped (anonymised) alarm hub payload. Includes unmodeled keys
+# (``buckboost``, the per-input ``resistor``/``trigger`` fields, ...) to prove
+# they are preserved on the opaque dict and ignored by the typed accessors.
+_ALARM_HUB_FIXTURE: dict[str, Any] = {
+    "id": ALARM_HUB_ID,
+    "modelKey": "linkstation",
+    "state": "CONNECTED",
+    "name": "Alarm Hub",
+    "mac": "AABBCCDDEEFF",
+    "isAlarmHub": True,
+    "ledSettings": {"isEnabled": True},
+    "lastEvent": 1780415883894,
+    "alarmHub": {
+        "armed": "off",
+        "buckboost": "on",  # unmodeled — must survive on the opaque dict
+        "battery": {
+            "batteryStatus": "ok",
+            "connection": "connected",
+            "voltage": 12.061495,
+        },
+        "cover": {"distance": 72, "status": "close"},
+        "output": {
+            "0": {
+                "active": "off",
+                "delay": 0,
+                "duration": 5000,
+                "enable": "on",
+                "status": "dry",
+            },
+            "1": {
+                "active": "off",
+                "delay": 0,
+                "duration": 5000,
+                "enable": "on",
+                "status": "dry",
+            },
+        },
+        "input": {
+            # Unconfigured zone: no inputType / name on the wire.
+            "0": {
+                "enable": "on",
+                "type": "no",
+                "status": "normal",
+                "resistor": 2.2,
+                "trigger": 3,
+            },
+            "16": {
+                "enable": "on",
+                "type": "nc",
+                "status": "normal",
+                "name": "24 Hour Tamper",
+                "inputType": "EMERGENCY_BUTTON",
+                "lastTriggeredAt": 1780317024117,
+            },
+            "24": {
+                "enable": "on",
+                "type": "nc",
+                "status": "normal",
+                "name": "Hallway",
+                "inputType": "MOTION",
+                "lastTriggeredAt": 1780414495310,
+                "cameraId": None,
+                "powerReset": False,
+            },
+            "25": {
+                "enable": "on",
+                "type": "nc",
+                "status": "normal",
+                "inputType": "ENTRY",
+                "lastTriggeredAt": 1780317516764,
+                "cameraId": None,
+            },
+            "28": {
+                "enable": "on",
+                "type": "nc",
+                "status": "normal",
+                "name": "Kitchen",
+                "inputType": "MOTION",
+                "lastTriggeredAt": 1780415831259,
+                "cameraId": "61b3a6a3009a1403870009c6",
+            },
+            # Forward-compat: an input type added by future firmware.
+            "30": {
+                "enable": "on",
+                "type": "no",
+                "status": "normal",
+                "inputType": "SOMETHING_NEW",
+            },
+        },
+    },
+}
+
+_LINK_STATION_FIXTURE: dict[str, Any] = {
+    "id": ALARM_HUB_ID,
+    "modelKey": "linkstation",
+    "state": "CONNECTED",
+    "name": "Garage Link",
+    "mac": "AABBCCDDEEFF",
+    "isAlarmHub": False,
+    "ledSettings": {"isEnabled": True},
+    "lastEvent": None,
+    "alarmHub": None,
+}
+
+
+def _hub() -> LinkStation:
+    return LinkStation.from_unifi_dict(**deepcopy(_ALARM_HUB_FIXTURE))
+
+
+def test_alarm_hub_armed() -> None:
+    assert _hub().alarm_hub_armed == "off"
+
+
+def test_alarm_hub_battery() -> None:
+    battery = _hub().alarm_hub_battery
+    assert isinstance(battery, AlarmHubBattery)
+    assert battery.battery_status == "ok"
+    assert battery.connection == "connected"
+    assert battery.voltage == pytest.approx(12.061495)
+
+
+def test_alarm_hub_cover() -> None:
+    cover = _hub().alarm_hub_cover
+    assert isinstance(cover, AlarmHubCover)
+    assert cover.status == "close"
+    assert cover.distance == 72
+
+
+def test_alarm_hub_outputs_keyed_by_int() -> None:
+    outputs = _hub().alarm_hub_outputs
+    assert set(outputs) == {0, 1}
+    assert all(isinstance(o, AlarmHubOutput) for o in outputs.values())
+    out0 = outputs[0]
+    assert out0.active == "off"
+    assert out0.status == "dry"
+    assert out0.enable == "on"
+    assert out0.delay == 0
+    assert out0.duration == 5000
+
+
+def test_alarm_hub_inputs_keyed_by_int() -> None:
+    inputs = _hub().alarm_hub_inputs
+    assert set(inputs) == {0, 16, 24, 25, 28, 30}
+    assert all(isinstance(i, AlarmHubInput) for i in inputs.values())
+
+
+def test_alarm_hub_input_configured_zone() -> None:
+    zone = _hub().alarm_hub_inputs[24]
+    assert zone.name == "Hallway"
+    assert zone.input_type is AlarmHubInputType.MOTION
+    assert zone.type == "nc"
+    assert zone.status == "normal"
+    assert zone.last_triggered_at == 1780414495310
+    assert zone.camera_id is None
+
+
+def test_alarm_hub_input_with_camera() -> None:
+    assert _hub().alarm_hub_inputs[28].camera_id == "61b3a6a3009a1403870009c6"
+
+
+def test_alarm_hub_input_emergency_button() -> None:
+    assert _hub().alarm_hub_inputs[16].input_type is AlarmHubInputType.EMERGENCY_BUTTON
+
+
+def test_alarm_hub_input_entry() -> None:
+    assert _hub().alarm_hub_inputs[25].input_type is AlarmHubInputType.ENTRY
+
+
+def test_alarm_hub_unconfigured_input_has_no_type() -> None:
+    assert _hub().alarm_hub_inputs[0].input_type is None
+    assert _hub().alarm_hub_inputs[0].name is None
+
+
+def test_alarm_hub_unknown_input_type_coerces_to_unknown() -> None:
+    # Forward-compat: a value not in the enum must coerce to UNKNOWN, not raise.
+    assert _hub().alarm_hub_inputs[30].input_type is AlarmHubInputType.UNKNOWN
+
+
+def test_alarm_hub_opaque_dict_preserved() -> None:
+    # The additive accessors must not strip unmodeled keys from the raw payload.
+    hub = _hub()
+    assert hub.alarm_hub is not None
+    assert hub.alarm_hub["buckboost"] == "on"
+    # Unmodeled per-input keys must survive untouched on the raw payload.
+    assert hub.alarm_hub["input"]["0"]["resistor"] == 2.2
+    assert hub.alarm_hub["input"]["24"]["powerReset"] is False
+
+
+def test_link_station_accessors_are_empty_when_not_hub() -> None:
+    ls = LinkStation.from_unifi_dict(**deepcopy(_LINK_STATION_FIXTURE))
+    assert ls.alarm_hub is None
+    assert ls.alarm_hub_armed is None
+    assert ls.alarm_hub_battery is None
+    assert ls.alarm_hub_cover is None
+    assert ls.alarm_hub_inputs == {}
+    assert ls.alarm_hub_outputs == {}
+
+
+def test_alarm_hub_accessors_with_missing_keys() -> None:
+    # Hub present, but a sparse payload (e.g. older firmware) omits sections.
+    fixture = deepcopy(_LINK_STATION_FIXTURE)
+    fixture["isAlarmHub"] = True
+    fixture["alarmHub"] = {}
+    hub = LinkStation.from_unifi_dict(**fixture)
+    assert hub.alarm_hub_armed is None
+    assert hub.alarm_hub_battery is None
+    assert hub.alarm_hub_cover is None
+    assert hub.alarm_hub_inputs == {}
+    assert hub.alarm_hub_outputs == {}


### PR DESCRIPTION
## What

Adds **read-only typed accessors** over the alarm-hub (`alarmHub`) payload on
`LinkStation`, without changing how the payload is stored.

New, exported from `uiprotect.data`:

- `AlarmHubBattery` — backup battery (`battery_status`, `connection`, `voltage`)
- `AlarmHubCover` — tamper cover (`status`, `distance`)
- `AlarmHubInput` — a wired input/zone (`enable`, `type`, `status`, `name`, `input_type`, `last_triggered_at`, `camera_id`)
- `AlarmHubOutput` — an output channel (`active`, `enable`, `status`, `delay`, `duration`)
- `AlarmHubInputType` — `MOTION` / `ENTRY` / `EMERGENCY_BUTTON` (+ `UNKNOWN` fallback)

…surfaced via properties on `LinkStation`: `alarm_hub_armed`, `alarm_hub_battery`,
`alarm_hub_cover`, `alarm_hub_inputs` (`dict[int, AlarmHubInput]`) and
`alarm_hub_outputs` (`dict[int, AlarmHubOutput]`).

## Why

`LinkStation.alarm_hub` is intentionally an opaque `dict[str, Any]` (its low-level
electrical maps use keys like `"12v"`/`"+"`/`"-"`). That's the right call for those
sections — but it pushes payload parsing onto consumers. The Home Assistant
`unifiprotect` integration is Platinum quality scale, where the
[thin-wrapper rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/)
means device/payload parsing should live in the library, not the integration. To
build alarm-hub entities (zone binary sensors, battery/tamper sensors) HA needs
typed fields.

## Approach

Purely **additive** and forward-compatible:

- The opaque `alarm_hub` dict is **left completely untouched** — unmodeled and
  future keys are preserved (covered by a regression test).
- The accessors parse only the useful, well-formed slice on demand and return
  `None` / `{}` when this isn't an alarm hub or a section is absent (older
  firmware / partial payloads), so callers never guard against the opaque shape.
- Enum/string coercion reuses the existing `convert_unifi_data` path, so unknown
  `inputType` values coerce to `UNKNOWN` rather than raising.

The model shapes are derived from a real `UP-AlarmHub-Kit` (`GET /v1/alarm-hubs`)
on Protect 7.1.75.

## Testing

- New `tests/test_alarm_hub.py` (15 tests): armed/battery/cover, int-keyed
  inputs/outputs, configured vs. unconfigured zones, camera-linked zone,
  unknown-type coercion, opaque-dict preservation, non-hub and sparse payloads.
- 100% line + branch coverage on the added code; `ruff` and `mypy` clean; full
  suite green (1427 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Alarm Hub support: typed read-only access to armed state, battery, tamper cover, input zones (motion, entry, emergency button + unknown fallback), and outputs; numeric channel keys only; accessors return None/empty when absent and do not mutate the raw payload.

* **Tests**
  * Extensive tests covering parsing, type coercion, numeric-channel filtering, preservation of opaque data, and device-absence cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->