### PR TITLE
fix(public-api): make alarm hub battery/cover fields optional

### DIFF
--- a/src/uiprotect/data/public_devices.py
+++ b/src/uiprotect/data/public_devices.py
@@ -403,18 +403,30 @@ class Speaker(ProtectModelWithId):
 
 
 class AlarmHubBattery(ProtectBaseObject):
-    """Backup battery status of an alarm hub (``alarmHub.battery`` sub-schema)."""
+    """
+    Backup battery status of an alarm hub (``alarmHub.battery`` sub-schema).
 
-    charging: OnOffState
-    connection: AlarmHubConnectionState
+    The ``battery`` object declares no ``required`` array in the OpenAPI spec,
+    and a real hub with the backup battery disconnected emits only
+    ``connection`` (omitting ``charging``/``voltage``/``batteryStatus``), so
+    every field is optional.
+    """
+
+    charging: OnOffState | None = None
+    connection: AlarmHubConnectionState | None = None
     voltage: float | None = None
-    battery_status: AlarmHubBatteryStatus
+    battery_status: AlarmHubBatteryStatus | None = None
 
 
 class AlarmHubCover(ProtectBaseObject):
-    """Tamper cover status of an alarm hub (``alarmHub.cover`` sub-schema)."""
+    """
+    Tamper cover status of an alarm hub (``alarmHub.cover`` sub-schema).
 
-    status: AlarmHubCoverStatus
+    The ``cover`` object declares no ``required`` array in the OpenAPI spec, so
+    both fields are optional.
+    """
+
+    status: AlarmHubCoverStatus | None = None
     distance: int | None = None
 
 

--- a/tests/test_api_linkstation_public.py
+++ b/tests/test_api_linkstation_public.py
@@ -74,6 +74,32 @@ def test_alarm_hub_cover_is_typed() -> None:
     assert cover.distance == 3
 
 
+def test_alarm_hub_battery_sparse_payload_when_disconnected() -> None:
+    # When the backup battery is disconnected the hub emits only ``connection``
+    # (observed on real hardware). The ``battery`` object has no ``required``
+    # array in the OpenAPI spec, so every sub-field must be optional.
+    data = _load_alarm_hub_fixture()
+    data["alarmHub"]["battery"] = {"connection": "disconnected"}
+    ls = LinkStation.from_unifi_dict(**data)
+    battery = ls.alarm_hub_battery
+    assert isinstance(battery, AlarmHubBattery)
+    assert battery.connection is AlarmHubConnectionState.DISCONNECTED
+    assert battery.charging is None
+    assert battery.voltage is None
+    assert battery.battery_status is None
+
+
+def test_alarm_hub_cover_sparse_payload() -> None:
+    # ``cover`` likewise has no ``required`` array in the spec.
+    data = _load_alarm_hub_fixture()
+    data["alarmHub"]["cover"] = {"distance": 66}
+    ls = LinkStation.from_unifi_dict(**data)
+    cover = ls.alarm_hub_cover
+    assert isinstance(cover, AlarmHubCover)
+    assert cover.distance == 66
+    assert cover.status is None
+
+
 def test_alarm_hub_inputs_keyed_by_int_and_non_numeric_skipped() -> None:
     ls = LinkStation.from_unifi_dict(**_load_alarm_hub_fixture())
     inputs = ls.alarm_hub_inputs


### PR DESCRIPTION
## What

Makes the `AlarmHubBattery` and `AlarmHubCover` sub-model fields optional (default `None`).

## Why

The `alarmHub.battery` and `alarmHub.cover` objects in the UniFi Protect Integration API OpenAPI spec (`alarmHubStatus` schema, v7.1.x) declare **no `required` array** — every sub-field is optional. The models introduced in #894/#896 marked `AlarmHubBattery.charging` / `.connection` / `.battery_status` and `AlarmHubCover.status` as **required**, which is stricter than the spec.

On real hardware this bites: when the hub's backup battery is **disconnected**, the hub emits only `battery: {"connection": "disconnected"}` and omits `charging`, `voltage`, and `batteryStatus`. With the required typing that raises `ValidationError` (debug) / leaves the attributes unset → `AttributeError` (production `model_construct`), so `LinkStation.alarm_hub_battery` is unusable in that state.

Observed on a live `UP-AlarmHub-Kit` (Protect 7.1.75) with the backup battery unplugged:
```json
"battery": {"connection": "disconnected"}
```

## Change

- `AlarmHubBattery`: `charging`, `connection`, `battery_status` → `... | None = None` (`voltage` was already optional).
- `AlarmHubCover`: `status` → `... | None = None` (`distance` was already optional).
- **`AlarmHubInput` / `AlarmHubOutput` are unchanged** — their `enable`/`type`/`status` (and `active`) fields *are* in the spec's `required` arrays, so they stay required.

## Spec reference

`alarmHubStatus.properties.battery` and `.cover` have no `required` array; `input`/`output` map items list `required: [enable, type, eolr, resistor, status, trigger]` and `[enable, active, status]` respectively. (Spec: UniFi Protect 7.1.77 integration OpenAPI.)

## Testing

- Added `test_alarm_hub_battery_sparse_payload_when_disconnected` and `test_alarm_hub_cover_sparse_payload`.
- Full suite green; `ruff`/`mypy` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced data model flexibility to better handle incomplete or sparse payloads received from alarm hub devices.
  * Improved support for disconnected backup battery scenarios with proper optional field handling.
  * More graceful handling of unspecified cover field values in sensor readings and status updates.

* **Tests**
  * Added comprehensive test coverage validating sparse payload handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->