### PR TITLE
fix(deps): relax pyjwt and av floors to unblock the HA lib bump

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3993,4 +3993,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "ff113ae623a4dd06541d21d016e3b05a243494582019a7f945624054b443c819"
+content-hash = "087ce7fdd2c035ffdfdfc7b4e8ba4f5efa6bf37501862bcddad28b0c7d7b8567"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,20 @@ python = ">=3.11"
 rich = ">=15.0.0"
 aiofiles = ">=24"
 aiohttp = ">=3.14.0"
-av = ">=17.0.1"
+# Temporarily lowered from >=17.0.1 so the Home Assistant lib bump is not
+# blocked on home-assistant/core#172892 (av 16->17). Re-raise once it lands.
+av = ">=16.0.1"
 dateparser = ">=1.1.0"
 orjson = ">=3.11.9"
 packaging = ">=26.2"
 pillow = ">=12.2.0"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.13.4"
-pyjwt = ">=2.13.0"
+# Temporarily lowered from >=2.13.0 so the Home Assistant lib bump is not
+# blocked on home-assistant/core#172893 (PyJWT 2.12->2.13). uiprotect only
+# decodes with verify_signature=False, so the 2.13.0 change is irrelevant
+# here; re-raise once that PR lands.
+pyjwt = ">=2.12.1"
 yarl = ">=1.24.2"
 typer = ">=0.26.0"
 convertertools = ">=0.5.0"


### PR DESCRIPTION
## Description of change

Temporarily lowers two dependency floors so the Home Assistant `unifiprotect` lib bump is not gated on two delayed, no-benefit dependency-bump PRs in `home-assistant/core`:

- `av`: `>=17.0.1` → `>=16.0.1` — unblocks home-assistant/core#172892 (av 16→17)
- `pyjwt`: `>=2.13.0` → `>=2.12.1` — unblocks home-assistant/core#172893 (PyJWT 2.12→2.13)

Both floors came from routine `chore(deps)` bumps (#843, #871), not a code requirement. Lowering is safe:

- **pyjwt** — `decode_token_cookie` calls `jwt.decode(..., options={"verify_signature": False})`. uiprotect never verifies signatures, so the PyJWT 2.13.0 empty-HMAC-key change (which is what forced the HA-side fix in #172893) cannot affect it.
- **av** — the talkback code (`stream.py`) uses `av.open`, `av.AudioResampler`, `av.audio.AudioStream` and `av.FFmpegError`; all are present in PyAV 16.x (`FFmpegError` exists since PyAV 14). Note: uiprotect introduced PyAV at 17.x, so 16.x is API-compatible but not part of the test matrix.

The locked versions (av 17.0.1, pyjwt 2.13.0) still satisfy the new floors, so only `poetry.lock`'s content-hash changes — no resolved-version churn.

**Temporary** — re-raise both floors once home-assistant/core#172892 and #172893 land. The inline `pyproject.toml` comments record this.

`fix(deps)` so semantic-release cuts a patch (11.0.2) HA can bump to.

## Checklist

- [x] The code change is tested and works locally (`poetry check` clean; installed deps unchanged, full suite unaffected).
- [x] There is no commented out code in this PR.
- [ ] I have followed the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md) — N/A beyond standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted minimum dependency versions for `av` and `pyjwt` to enable compatibility with earlier library releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->