### PR TITLE
feat(deps): make typer an optional cli extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           cache: "poetry"
       - name: Install Dependencies
         run: |
-          poetry install
+          poetry install --all-extras
       - uses: pre-commit/action@v3.0.1
 
   # Make sure the PR title follows the conventional commits convention:
@@ -84,7 +84,7 @@ jobs:
           allow-prereleases: true
       - run: echo "Cache hit:${{ steps.setup-python.outputs.cache-hit }}" # true if cache-hit occurred on the primary key
       - name: Install Dependencies
-        run: poetry install
+        run: poetry install --all-extras
       - name: Test with Pytest
         run: ./.bin/test-code
         shell: bash

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 tasks:
   - command: |
       pip install poetry
-      PIP_USER=false poetry install
+      PIP_USER=false poetry install --all-extras
   - command: |
       pip install pre-commit
       pre-commit install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,11 @@ Ready to contribute? Here's how to set yourself up for local development.
 3. Install the project dependencies with [Poetry](https://python-poetry.org):
 
    ```shell
-   $ poetry install
+   $ poetry install --all-extras
    ```
+
+   `--all-extras` pulls in the optional `cli` extra (`typer`) so the
+   CLI and its tests (`tests/test_cli.py`) work in your environment.
 
 4. Create a branch for local development:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ FROM base AS prod
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/
 COPY --from=prod-builder /tmp/build/dist/*.whl /tmp/
 RUN --mount=type=cache,mode=0755,id=pip-$TARGETPLATFORM,target=/root/.cache \
-    uv pip install -U /tmp/*.whl \
+    uv pip install -U "$(echo /tmp/*.whl)[cli]" \
     && rm /tmp/*.whl
 
 COPY .docker/entrypoint.sh /usr/local/bin/entrypoint
@@ -58,7 +58,7 @@ WORKDIR /workspaces/uiprotect
 COPY pyproject.toml poetry.lock ./
 RUN --mount=type=cache,mode=0755,id=pip-$TARGETPLATFORM,target=/root/.cache \
     poetry config virtualenvs.create false \
-    && poetry install --with dev --no-root --no-interaction --no-ansi
+    && poetry install --with dev --all-extras --no-root --no-interaction --no-ansi
 
 FROM base AS dev
 
@@ -116,4 +116,4 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 
 COPY pyproject.toml poetry.lock* ./
 RUN --mount=type=cache,mode=0755,id=pip-$TARGETPLATFORM,target=/root/.cache \
-    poetry install --with dev --no-root
+    poetry install --with dev --all-extras --no-root

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ FROM base AS prod
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/
 COPY --from=prod-builder /tmp/build/dist/*.whl /tmp/
 RUN --mount=type=cache,mode=0755,id=pip-$TARGETPLATFORM,target=/root/.cache \
-    uv pip install -U "$(echo /tmp/*.whl)[cli]" \
+    uv pip install -U "uiprotect[cli] @ file://$(echo /tmp/*.whl)" \
     && rm /tmp/*.whl
 
 COPY .docker/entrypoint.sh /usr/local/bin/entrypoint

--- a/README.md
+++ b/README.md
@@ -199,10 +199,18 @@ Windows is **not supported**. If you need to use `uiprotect` on Windows, use Doc
 pip install uiprotect
 ```
 
+To use the command-line interface, install the `cli` extra (it pulls in `typer`):
+
+```bash
+pip install "uiprotect[cli]"
+```
+
 ### From GitHub
 
 ```bash
 pip install git+https://github.com/uilibs/uiprotect.git#egg=uiprotect
+# with the CLI:
+pip install "uiprotect[cli] @ git+https://github.com/uilibs/uiprotect.git"
 ```
 
 ### Using Docker Container

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The recommended way to develop is using the provided **devcontainer** with VS Co
 Alternatively, if you want to develop natively without devcontainer:
 
 ```bash
-# Install dependencies
-poetry install --with dev
+# Install dependencies (--all-extras installs the cli extra for CLI tests)
+poetry install --with dev --all-extras
 
 # Install pre-commit hooks
 poetry run pre-commit install --install-hooks

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,4 +8,11 @@ The package is published on [PyPI](https://pypi.org/project/uiprotect/) and can 
 pip install uiprotect
 ```
 
+To use the command-line interface (the `uiprotect` console script), install
+the `cli` extra, which pulls in [`typer`](https://typer.tiangolo.com/):
+
+```bash
+pip install "uiprotect[cli]"
+```
+
 Next, see the {ref}`section about usage <usage>` to see how to use it.

--- a/poetry.lock
+++ b/poetry.lock
@@ -248,9 +248,10 @@ files = [
 name = "annotated-doc"
 version = "0.0.4"
 description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"cli\""
 files = [
     {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
     {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
@@ -649,7 +650,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+markers = {main = "extra == \"cli\" and platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "convertertools"
@@ -3165,9 +3166,10 @@ files = [
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"cli\""
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
@@ -3443,9 +3445,10 @@ tests = ["pytest", "pytest-cov"]
 name = "typer"
 version = "0.26.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"cli\""
 files = [
     {file = "typer-0.26.0-py3-none-any.whl", hash = "sha256:859d520a4dc91c075cb370195462b6f7024fceb5d6de5c204bb8b1d51a60ad66"},
     {file = "typer-0.26.0.tar.gz", hash = "sha256:08177aa85fd81ceb6e8f7cb879cf22dbaa81f98c02b7d570acf112513d2aa66f"},
@@ -3990,7 +3993,10 @@ idna = ">=2.0"
 multidict = ">=4.0"
 propcache = ">=0.2.1"
 
+[extras]
+cli = ["typer"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "087ce7fdd2c035ffdfdfc7b4e8ba4f5efa6bf37501862bcddad28b0c7d7b8567"
+content-hash = "e9f327da785b106e62617b6241fb35d6c68e3453037f238fe143dd59c8b72b2a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 dynamic = ["classifiers", "dependencies"]
 
+[project.optional-dependencies]
+cli = ["typer>=0.26.0"]
+
 [project.urls]
 "Repository" = "https://github.com/uilibs/uiprotect"
 "Documentation" = "https://uiprotect.readthedocs.io"
@@ -50,7 +53,7 @@ pydantic = ">=2.13.4"
 # here; re-raise once that PR lands.
 pyjwt = ">=2.12.1"
 yarl = ">=1.24.2"
-typer = ">=0.26.0"
+typer = { version = ">=0.26.0", optional = true }
 convertertools = ">=0.5.0"
 propcache = ">=0.5.2"
 pydantic-extra-types = ">=2.10.1"

--- a/src/uiprotect/utils.py
+++ b/src/uiprotect/utils.py
@@ -463,12 +463,16 @@ def print_ws_stat_summary(
     stats: list[WSStat],
     output: Callable[[Any], Any] | None = None,
 ) -> None:
-    # typer<0.4.1 is incompatible with click>=8.1.0
-    # allows only the CLI interface to break if both are installed
-    import typer  # noqa: PLC0415
-
     if output is None:
-        output = typer.echo if typer is not None else print
+        # typer<0.4.1 is incompatible with click>=8.1.0, so the import is
+        # deferred to keep that breakage CLI-only. typer is also an optional
+        # dependency (the `cli` extra); fall back to print when it is absent.
+        try:
+            import typer  # noqa: PLC0415
+
+            output = typer.echo
+        except ImportError:
+            output = print
 
     unfiltered, percent, keys, models, actions = ws_stat_summmary(stats)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -696,6 +696,22 @@ def test_print_ws_stat_summary():
     assert "camera: 1" in lines[0]
 
 
+def test_print_ws_stat_summary_default_output(capsys):
+    """Uses typer.echo (stdout) as the default output when no callable is given."""
+    stats = [
+        WSStat(
+            model="camera",
+            action="update",
+            keys=["name"],
+            keys_set=["name"],
+            size=100,
+            filtered=False,
+        )
+    ]
+    print_ws_stat_summary(stats)
+    assert "camera: 1" in capsys.readouterr().out
+
+
 def test_print_ws_stat_summary_without_typer(monkeypatch, capsys):
     """Falls back to print when the optional typer (cli extra) is absent."""
     monkeypatch.setitem(sys.modules, "typer", None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import time as time_module
 import zoneinfo
 from datetime import UTC, datetime, timedelta
@@ -693,6 +694,23 @@ def test_print_ws_stat_summary():
     lines: list[str] = []
     print_ws_stat_summary(stats, output=lines.append)
     assert "camera: 1" in lines[0]
+
+
+def test_print_ws_stat_summary_without_typer(monkeypatch, capsys):
+    """Falls back to print when the optional typer (cli extra) is absent."""
+    monkeypatch.setitem(sys.modules, "typer", None)
+    stats = [
+        WSStat(
+            model="camera",
+            action="update",
+            keys=["name"],
+            keys_set=["name"],
+            size=100,
+            filtered=False,
+        )
+    ]
+    print_ws_stat_summary(stats)
+    assert "camera: 1" in capsys.readouterr().out
 
 
 # --- write_json tests ---


### PR DESCRIPTION


<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
typer is only used by the CLI entry point (uiprotect.cli:app). Move it out of the mandatory dependencies into a cli extra so library consumers (e.g. Home Assistant) are no longer forced to satisfy typer's version constraints.

Install with pip install "uiprotect[cli]" to get the CLI. The Docker image, dev/devcontainer builds and CI install the extra so the CLI and its tests keep working.
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI is now optional; install the CLI extra to enable the command-line interface.

* **Documentation**
  * Installation and developer docs updated with instructions to install the CLI extra.

* **Chores**
  * CI, devcontainer, local setup and container builds now install all optional extras during setup.

* **Bug Fixes**
  * Runtime now safely handles missing CLI tooling and falls back to a default output method.

* **Tests**
  * Added tests covering output behavior with and without the optional CLI dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->