### PR TITLE
feat(deps): move cli-only dependencies (rich, dateparser, pillow) into the cli extra

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -835,9 +835,10 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 name = "dateparser"
 version = "1.4.0"
 description = "Date parsing library designed to parse dates from HTML pages"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"cli\""
 files = [
     {file = "dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378"},
     {file = "dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4"},
@@ -1355,6 +1356,7 @@ files = [
     {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
     {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
 ]
+markers = {main = "extra == \"cli\""}
 
 [package.dependencies]
 mdurl = ">=0.1,<1.0"
@@ -1498,6 +1500,7 @@ files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
+markers = {main = "extra == \"cli\""}
 
 [[package]]
 name = "mergedeep"
@@ -2133,9 +2136,10 @@ tests = ["pytest (>=9)", "typing-extensions (>=4.15)"]
 name = "pillow"
 version = "12.2.0"
 description = "Python Imaging Library (fork)"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"cli\""
 files = [
     {file = "pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f"},
     {file = "pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97"},
@@ -2621,6 +2625,7 @@ files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
+markers = {main = "extra == \"cli\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -2869,6 +2874,7 @@ files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
+markers = {main = "extra == \"cli\""}
 
 [package.dependencies]
 six = ">=1.5"
@@ -2877,9 +2883,10 @@ six = ">=1.5"
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"cli\""
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
@@ -2987,9 +2994,10 @@ pyyaml = "*"
 name = "regex"
 version = "2025.9.18"
 description = "Alternative regular expression module, to replace re."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"cli\""
 files = [
     {file = "regex-2025.9.18-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:12296202480c201c98a84aecc4d210592b2f55e200a1d193235c4db92b9f6788"},
     {file = "regex-2025.9.18-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:220381f1464a581f2ea988f2220cf2a67927adcef107d47d6897ba5a2f6d51a4"},
@@ -3142,6 +3150,7 @@ files = [
     {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
     {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
 ]
+markers = {main = "extra == \"cli\""}
 
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
@@ -3186,6 +3195,7 @@ files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
+markers = {main = "extra == \"cli\""}
 
 [[package]]
 name = "smmap"
@@ -3528,9 +3538,10 @@ markers = {docs = "sys_platform == \"win32\""}
 name = "tzlocal"
 version = "5.3.1"
 description = "tzinfo object for the local timezone"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"cli\""
 files = [
     {file = "tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"},
     {file = "tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd"},
@@ -3994,9 +4005,9 @@ multidict = ">=4.0"
 propcache = ">=0.2.1"
 
 [extras]
-cli = ["typer"]
+cli = ["dateparser", "pillow", "rich", "typer"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "e9f327da785b106e62617b6241fb35d6c68e3453037f238fe143dd59c8b72b2a"
+content-hash = "d6d93f7ab6e91196096e9da2121d75e39ff043f50d4530b04775100774e3a7c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ requires-python = ">=3.11"
 dynamic = ["classifiers", "dependencies"]
 
 [project.optional-dependencies]
-cli = ["typer>=0.26.0"]
+cli = [
+    "typer>=0.26.0",
+    "rich>=15.0.0",
+    "dateparser>=1.1.0",
+    "pillow>=12.2.0",
+]
 
 [project.urls]
 "Repository" = "https://github.com/uilibs/uiprotect"
@@ -35,16 +40,16 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.11"
-rich = ">=15.0.0"
+rich = { version = ">=15.0.0", optional = true }
 aiofiles = ">=24"
 aiohttp = ">=3.14.0"
 # Temporarily lowered from >=17.0.1 so the Home Assistant lib bump is not
 # blocked on home-assistant/core#172892 (av 16->17). Re-raise once it lands.
 av = ">=16.0.1"
-dateparser = ">=1.1.0"
+dateparser = { version = ">=1.1.0", optional = true }
 orjson = ">=3.11.9"
 packaging = ">=26.2"
-pillow = ">=12.2.0"
+pillow = { version = ">=12.2.0", optional = true }
 platformdirs = ">=4.9.6"
 pydantic = ">=2.13.4"
 # Temporarily lowered from >=2.13.0 so the Home Assistant lib bump is not


### PR DESCRIPTION
## Proposed change

Follow-up to #916. Moves the remaining CLI-only dependencies — `rich`, `dateparser` and `pillow` — out of the mandatory dependencies and into the existing `cli` extra, matching how `typer` was handled in #916.

These are not imported by the library core:

- `rich` — only `rich.progress` in `src/uiprotect/cli/` (4 sites)
- `dateparser` — only `src/uiprotect/cli/backup.py`
- `pillow` — only `src/uiprotect/cli/backup.py` and `src/uiprotect/test_util/` (the latter is reached solely through the `generate-sample-data` CLI command and is not part of the public API)

Library consumers (e.g. Home Assistant) import only the Python API and therefore no longer need to satisfy the version constraints of these packages. The CLI continues to pull them in via `pip install "uiprotect[cli]"`.

Verified: with `rich`/`dateparser`/`pillow` absent, `from uiprotect import ProtectApiClient` plus `data`/`websocket`/`stream`/`events` import cleanly; `uiprotect.cli` correctly raises without the extra. Wheel metadata gates all four on `extra == "cli"`; core deps stay unconditional.

No Docker/CI/docs changes needed — the prod image installs `[cli]`, CI/dev use `--all-extras`, and the install docs already point to `uiprotect[cli]`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented-out code in this PR.
- [x] Tests have been added/updated where applicable. (N/A — dependency-declaration change; existing CLI/import tests cover it)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency configuration to use structured optional dependency syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->