### PR TITLE
docs: require 100% patch coverage for every PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,16 @@ coverage-aware, xdist-parallel run. `pytest-asyncio` is used in
 the default per-test mode (no auto mode); async tests are marked
 explicitly with `@pytest.mark.asyncio`.
 
+**Every PR must reach 100% patch coverage.** Each line you add or
+change under `src/uiprotect/` has to be exercised by a test —
+check the `--cov-report=term-missing` output and confirm none of
+the diff's lines appear as missing before pushing. Don't ship a
+change with uncovered new code; if a line is genuinely
+unreachable, mark it `# pragma: no cover` with a one-line reason
+rather than leaving it untested. This applies to automated
+contributions too: a PR that adds production code without the
+tests to cover it is incomplete.
+
 The test suite is fixture-driven: `tests/sample_data/` holds
 captured bootstrap JSON / WebSocket frames from real Protect
 consoles and `tests/conftest.py` loads them into the mock client.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,8 @@ explicitly with `@pytest.mark.asyncio`.
 
 **Every PR must reach 100% patch coverage.** Each line you add or
 change under `src/uiprotect/` has to be exercised by a test —
-check the `--cov-report=term-missing` output and confirm none of
-the diff's lines appear as missing before pushing. Don't ship a
+check the `--cov-report=term-missing:skip-covered` output and confirm
+none of the diff's lines appear as missing before pushing. Don't ship a
 change with uncovered new code; if a line is genuinely
 unreachable, mark it `# pragma: no cover` with a one-line reason
 rather than leaving it untested. This applies to automated


### PR DESCRIPTION
## What

Adds an explicit **100% patch coverage** requirement to the `AGENTS.md` → "Running tests" section: every added/changed line under `src/uiprotect/` must be exercised by a test, verified via the existing `--cov-report=term-missing` output, with `# pragma: no cover` (plus a reason) as the only escape hatch for genuinely unreachable lines.

## Why

The default pytest run is already coverage-aware (`--cov=uiprotect --cov-report=term-missing:skip-covered`), but nothing states that new code must actually be covered — so PRs (including automated ones) keep landing with uncovered changes. This makes the expectation explicit where contributors and coding agents read it (`AGENTS.md`, included by `CLAUDE.md`).

Docs-only change; no code or CI behavior is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to require 100% patch test coverage for added or modified production code in the UI protection area.
  * Contributors must verify coverage output and mark truly unreachable lines with an explicit no-cover marker plus a one-line rationale.
  * Contributions lacking tests for new production code will be considered incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->