### PR TITLE
test: skip cli-extra modules when Pillow/typer are absent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,10 +167,11 @@ depending on it.
 
 ## Running tests
 
-Requires Python >=3.11. **Install all extras first** — the `cli` extra
-provides Pillow and typer, without which `tests/test_api.py` and
-`tests/test_cli.py` fail at _collection_ (`ModuleNotFoundError`), which
-pytest reports as a full-session failure:
+Requires Python >=3.11. **Install all extras to run the full suite** — the
+`cli` extra provides Pillow, typer and rich. Without it the CLI/Pillow test
+modules (`tests/test_api.py`, `tests/test_cli.py`, `tests/test_dunder_main.py`)
+are skipped via `pytest.importorskip` rather than run, so a bare install
+silently exercises a reduced suite:
 
 ```bash
 poetry install --all-extras

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,13 @@ depending on it.
 
 ## Running tests
 
+Requires Python >=3.11. **Install all extras first** — the `cli` extra
+provides Pillow and typer, without which `tests/test_api.py` and
+`tests/test_cli.py` fail at _collection_ (`ModuleNotFoundError`), which
+pytest reports as a full-session failure:
+
 ```bash
+poetry install --all-extras
 poetry run pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ select = [
     "DTZ001", # tests intentionally construct naive datetimes
     "DTZ005", # tests intentionally call datetime.now() without tz
     "ERA001", # test fixtures keep commented-out reference snippets
+    "E402",   # optional-dependency guards (pytest.importorskip) precede imports
 ]
 "setup.py" = ["D100"]
 "conftest.py" = ["D100"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,11 @@ import aiohttp
 import orjson
 import pytest
 from aiofiles import os as aos
+
+# Pillow ships with the optional `cli` extra; skip the whole module rather than
+# fail at collection when it's absent (a minimal install without --all-extras).
+pytest.importorskip("PIL")
+
 from PIL import Image
 
 from tests.conftest import (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
-# typer/rich ship with the optional `cli` extra; skip the whole module rather
-# than fail at collection when it's absent (a minimal install without --all-extras).
-pytest.importorskip("typer")
+# The CLI stack (typer + rich) ships with the optional `cli` extra; importing
+# uiprotect.cli pulls the whole chain, so skip the module when any part is
+# absent (a minimal install without --all-extras) instead of failing collection.
+pytest.importorskip("uiprotect.cli")
 
 from typer.testing import CliRunner
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,12 @@ import ssl
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
+import pytest
+
+# typer/rich ship with the optional `cli` extra; skip the whole module rather
+# than fail at collection when it's absent (a minimal install without --all-extras).
+pytest.importorskip("typer")
+
 from typer.testing import CliRunner
 
 from uiprotect.cli import _is_ssl_error, app

--- a/tests/test_dunder_main.py
+++ b/tests/test_dunder_main.py
@@ -3,9 +3,10 @@ import sys
 
 import pytest
 
-# uiprotect.__main__ imports the typer-based CLI (optional `cli` extra); skip
-# rather than fail at collection when it's absent.
-pytest.importorskip("typer")
+# uiprotect.__main__ imports uiprotect.cli, which pulls the whole CLI stack
+# (typer + rich) from the optional `cli` extra; skip rather than fail at
+# collection when any part is absent.
+pytest.importorskip("uiprotect.cli")
 
 import uiprotect.__main__ as dunder_main
 

--- a/tests/test_dunder_main.py
+++ b/tests/test_dunder_main.py
@@ -1,6 +1,12 @@
 import subprocess
 import sys
 
+import pytest
+
+# uiprotect.__main__ imports the typer-based CLI (optional `cli` extra); skip
+# rather than fail at collection when it's absent.
+pytest.importorskip("typer")
+
 import uiprotect.__main__ as dunder_main
 
 


### PR DESCRIPTION
### Description of change

Three test modules import the optional `cli` extra at module top — `tests/test_api.py` (`from PIL import Image`), `tests/test_cli.py` (`typer` + the whole `uiprotect.cli` package), and `tests/test_dunder_main.py` (`uiprotect.__main__`, which imports the typer CLI). In any environment installed **without** `--all-extras`, these fail at *collection*, and pytest treats a collection `ImportError` as a hard, whole-session failure — independent of what the change under test is.

This is what makes automated/sandbox runs that don't install extras report "tests failed" on every change, even diffs that touch no Python (e.g. a CI-workflow-only PR), while GitHub CI — which provisions the full environment — stays green.

This PR:
- Guards each of the three modules with `pytest.importorskip(...)` so a minimal install **skips** them cleanly instead of erroring at collection. Verified: with `pillow`/`typer` uninstalled the three modules report `3 skipped` (not errors); with extras present the full suite still passes (`1636 passed`).
- Documents the requirement in `AGENTS.md` → *Running tests* now states Python `>=3.11` and `poetry install --all-extras` before `pytest`, with the reason.
- Allows `E402` in `tests/**` (per-file-ignore) for the `importorskip`-before-import guard pattern.

No production code changes; CI behaviour is unchanged (extras are always installed there).

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` — N/A
- [x] There are new or updated unit tests validating the change — the guards are exercised by the existing modules (skip vs. run depending on extras)
- [x] Documentation has been updated to reflect this change — `AGENTS.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tests now skip gracefully when optional dependencies are missing, preventing collection/import failures.

* **Documentation**
  * Clarified testing guidance: Python >=3.11 required and install all extras to run the full test suite.

* **Chores**
  * Adjusted test and lint configuration to better accommodate optional-dependency guards during test collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->