### PR TITLE
fix(deps): relax av floor to >=17.0.1 for Home Assistant compatibility

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3365,4 +3365,4 @@ cli = ["dateparser", "pillow", "rich", "typer"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "cf96bf6f0ed3f30ee97269e57ee7762257b642889b140f07fa18c7fa11a29cd7"
+content-hash = "de3b08b0b1392dabe625e012e30f4996849d6e0e42f941fa2341853c55077587"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ python = ">=3.11"
 rich = { version = ">=15.0.0", optional = true }
 aiofiles = ">=24"
 aiohttp = ">=3.14.1"
-av = ">=17.1.0"
+av = ">=17.0.1"
 dateparser = { version = ">=1.1.0", optional = true }
 orjson = ">=3.11.9"
 packaging = ">=26.2"


### PR DESCRIPTION
#976 bumped the `av` lower bound to `>=17.1.0`. As a library, our floor must stay at or below what downstream consumers pin: Home Assistant core hard-pins `av==17.0.1` globally (and in its `stream`/`generic` integrations), so `uiprotect==13.1.0` cannot be resolved there:

```
Because uiprotect==13.1.0 depends on av>=17.1.0 and you require av==17.0.1,
we can conclude that your requirements and uiprotect==13.1.0 are incompatible.
```

We use only stable PyAV APIs (`av.open`, `av.AudioResampler`, `av.FFmpegError`, `av.VideoFrame`/`AudioFrame`, `av.logging`) — nothing requires 17.1.0. This restores the previous floor; the resolved lock stays at 17.1.0, which still satisfies `>=17.0.1`.

Unblocks home-assistant/core#173584 (bump to uiprotect 13.1.x).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency compatibility to support earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->