### PR TITLE
ci(spec): disable schedule until deb download works off-datacenter

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -8,9 +8,9 @@ name: Spec conformance
 # spec (~74 MB deb) is fetched ephemerally and never committed or uploaded.
 
 on:
-  schedule:
-    # Daily at 06:17 UTC. Cheap until a release actually drifts.
-    - cron: "17 6 * * *"
+  # schedule disabled: deb download (fw-download.ubnt.com) returns 403 from
+  # GitHub-hosted runners (datacenter IP block). Re-enable once a direct spec
+  # download or self-hosted runner is in place.
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
The spec-validation cron was failing at the "Fetch spec and validate" step with HTTP 403 from `fw-download.ubnt.com`. Investigation confirmed this is a datacenter IP block by Cloudflare — the same download works fine from a residential IP (HTTP 206) but fails systematically from GitHub-hosted runners.

Other projects that run UniFi Protect in Docker (`dciancu/unifi-protect-unvr-docker-arm64`) avoid this by never downloading the deb from CI — they fetch it off-datacenter and bring it in as a local artifact.

Disabling the schedule until one of the following is resolved:
- Ubiquiti provides a directly downloadable spec (requested)
- A self-hosted runner (residential IP) is wired up for this job

`workflow_dispatch` still works for manual runs from a machine with a residential IP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated spec validation scheduling due to infrastructure connectivity issues. Validation can be re-enabled once an alternative runner or download method is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->