### PR TITLE
ci(spec): drop alarm-hub methods from _EXAMPLE_CALLS after decoration

### DIFF
--- a/scripts/validate_spec.py
+++ b/scripts/validate_spec.py
@@ -137,9 +137,6 @@ _EXAMPLE_CALLS: dict[str, Callable[[ProtectApiClient], Awaitable[Any]]] = {
         lambda c: c.activate_relay_output_public(_S, _S, state="on")
     ),
     "test_speaker_sound_public": lambda c: c.test_speaker_sound_public(_S),
-    "get_alarm_hubs_public": lambda c: c.get_alarm_hubs_public(),
-    "get_alarm_hub_public": lambda c: c.get_alarm_hub_public(_S),
-    "update_alarm_hub_public": lambda c: c.update_alarm_hub_public(_S, name=_S),
     "trigger_alarm_hub_output_public": (
         lambda c: c.trigger_alarm_hub_output_public(_S, _S, enable=True)
     ),


### PR DESCRIPTION
## Problem

`main` is red: `tests/test_validate_spec.py::test_example_calls_match_nondeclarative_coroutines` fails. The recorded-example-call table no longer matches the set of non-declarative public coroutines:

```
stale entries (now declarative, must be removed):
  - get_alarm_hubs_public
  - get_alarm_hub_public
  - update_alarm_hub_public
```

## Cause

#1012 decorated these three alarm-hub methods with `@public_get`/`@public_patch`, making them declarative — their endpoints are now derived from the registry. But #1012 branched before #988 (which introduced the conformance test), so its CI never ran `test_example_calls_match_nondeclarative_coroutines`. Each PR was green against its own base; the combination left `main` red. This is the exact merge-order semantic conflict that 'require branches up to date before merging' would have caught.

## Fix

Remove the three now-declarative methods from `_EXAMPLE_CALLS`. Coverage is preserved via the registry (`trigger_alarm_hub_output_public` stays — still non-declarative). All 29 `test_validate_spec.py` tests pass locally.