### PR TITLE
feat(sensor): support USL-Environmental leak detection (leakSettings + external probe)

### DIFF
--- a/src/uiprotect/data/devices.py
+++ b/src/uiprotect/data/devices.py
@@ -3363,6 +3363,15 @@ class SensorStats(ProtectBaseObject):
     temperature: SensorStat
 
 
+class SensorLeakSettings(ProtectBaseObject):
+    # USL-Environmental (SuperLink Environmental Sensor) exposes two independent
+    # leak channels: the onboard water pads (internal) and the 3.5mm AUX probe
+    # (external). Either being enabled means the device is acting as a leak sensor,
+    # regardless of mount_type (which is "none" on these devices).
+    is_internal_enabled: bool = False
+    is_external_enabled: bool = False
+
+
 class Sensor(ProtectAdoptableDeviceModel):
     alarm_settings: SensorSettingsBase
     alarm_triggered_at: datetime | None = None
@@ -3372,6 +3381,8 @@ class Sensor(ProtectAdoptableDeviceModel):
     is_motion_detected: bool
     is_opened: bool
     leak_detected_at: datetime | None = None
+    external_leak_detected_at: datetime | None = None
+    leak_settings: SensorLeakSettings | None = None
     led_settings: LEDSettings
     light_settings: SensorThresholdSettings
     motion_detected_at: datetime | None = None
@@ -3403,6 +3414,7 @@ class Sensor(ProtectAdoptableDeviceModel):
             "batteryStatus",
             "isMotionDetected",
             "leakDetectedAt",
+            "externalLeakDetectedAt",
             "tamperingDetectedAt",
             "isOpened",
             "openStatusChangedAt",
@@ -3477,7 +3489,17 @@ class Sensor(ProtectAdoptableDeviceModel):
 
     @property
     def is_leak_sensor_enabled(self) -> bool:
-        return self.mount_type is MountType.LEAK
+        # Legacy UniFi Sensor (UP-Sense) selects a single role via mount_type.
+        # The USL-Environmental keeps mount_type="none" and enables leak detection
+        # via leak_settings (internal pads and/or external AUX probe) instead.
+        if self.mount_type is MountType.LEAK:
+            return True
+        if self.leak_settings is not None:
+            return (
+                self.leak_settings.is_internal_enabled
+                or self.leak_settings.is_external_enabled
+            )
+        return False
 
     def set_alarm_timeout(self) -> None:
         self._alarm_timeout = utc_now() + EVENT_PING_INTERVAL
@@ -3509,7 +3531,20 @@ class Sensor(ProtectAdoptableDeviceModel):
 
     @property
     def is_leak_detected(self) -> bool:
+        return (
+            self.leak_detected_at is not None
+            or self.external_leak_detected_at is not None
+        )
+
+    @property
+    def is_internal_leak_detected(self) -> bool:
+        """Leak detected by the onboard water pads."""
         return self.leak_detected_at is not None
+
+    @property
+    def is_external_leak_detected(self) -> bool:
+        """Leak detected by the external 3.5mm AUX leak probe."""
+        return self.external_leak_detected_at is not None
 
     async def set_status_light(self, enabled: bool) -> None:
         """Sets the status indicator light for the sensor"""

--- a/tests/data/test_sensor.py
+++ b/tests/data/test_sensor.py
@@ -583,7 +583,12 @@ def test_sensor_leak_enabled_legacy_mount_type(sensor_obj: Sensor):
 @pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")
 @pytest.mark.parametrize(
     ("internal", "external", "expected"),
-    [(False, False, False), (True, False, True), (False, True, True), (True, True, True)],
+    [
+        (False, False, False),
+        (True, False, True),
+        (False, True, True),
+        (True, True, True),
+    ],
 )
 def test_sensor_leak_enabled_via_leak_settings(
     sensor_obj: Sensor, internal: bool, external: bool, expected: bool

--- a/tests/data/test_sensor.py
+++ b/tests/data/test_sensor.py
@@ -9,8 +9,10 @@ import pytest
 from pydantic import ValidationError
 
 from tests.conftest import TEST_CAMERA_EXISTS, TEST_SENSOR_EXISTS
+from uiprotect.data.devices import SensorLeakSettings
 from uiprotect.data.types import MountType, SensorScheduleMode
 from uiprotect.exceptions import BadRequest
+from uiprotect.utils import utc_now
 
 if TYPE_CHECKING:
     from uiprotect.data import Camera, Light, Sensor
@@ -564,3 +566,54 @@ async def test_sensor_set_glass_break_status_public(sensor_obj: Sensor, enabled:
     sensor_obj.api.update_sensor_public.assert_called_once_with(
         sensor_obj.id, glass_break_settings={"isEnabled": enabled}
     )
+
+
+@pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")
+def test_sensor_leak_enabled_legacy_mount_type(sensor_obj: Sensor):
+    # Legacy UniFi Sensor (UP-Sense): leak role is selected via mount_type and
+    # there are no leak_settings.
+    sensor_obj.leak_settings = None
+    sensor_obj.mount_type = MountType.LEAK
+    assert sensor_obj.is_leak_sensor_enabled is True
+
+    sensor_obj.mount_type = MountType.DOOR
+    assert sensor_obj.is_leak_sensor_enabled is False
+
+
+@pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")
+@pytest.mark.parametrize(
+    ("internal", "external", "expected"),
+    [(False, False, False), (True, False, True), (False, True, True), (True, True, True)],
+)
+def test_sensor_leak_enabled_via_leak_settings(
+    sensor_obj: Sensor, internal: bool, external: bool, expected: bool
+):
+    # USL-Environmental (SuperLink Environmental Sensor): mount_type stays NONE and
+    # leak detection is governed by leak_settings (internal pads / external probe).
+    sensor_obj.mount_type = MountType.NONE
+    sensor_obj.leak_settings = SensorLeakSettings(
+        is_internal_enabled=internal, is_external_enabled=external
+    )
+    assert sensor_obj.is_leak_sensor_enabled is expected
+
+
+@pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")
+def test_sensor_external_leak_detected(sensor_obj: Sensor):
+    sensor_obj.leak_detected_at = None
+    sensor_obj.external_leak_detected_at = None
+    assert sensor_obj.is_leak_detected is False
+    assert sensor_obj.is_internal_leak_detected is False
+    assert sensor_obj.is_external_leak_detected is False
+
+    # external AUX probe leak
+    sensor_obj.external_leak_detected_at = utc_now()
+    assert sensor_obj.is_external_leak_detected is True
+    assert sensor_obj.is_internal_leak_detected is False
+    assert sensor_obj.is_leak_detected is True
+
+    # internal onboard-pad leak
+    sensor_obj.external_leak_detected_at = None
+    sensor_obj.leak_detected_at = utc_now()
+    assert sensor_obj.is_internal_leak_detected is True
+    assert sensor_obj.is_external_leak_detected is False
+    assert sensor_obj.is_leak_detected is True


### PR DESCRIPTION
## Summary

Adds first-class leak support for the **UniFi Protect SuperLink Environmental Sensor** (`USL-Environmental-US`), whose `moisture`/leak state is currently reported as **unavailable** by downstream consumers (e.g. the Home Assistant `unifiprotect` integration) even when leak detection is enabled and working.

## Root cause

The Environmental Sensor is a distinct, multi-function device from the legacy universal UniFi Sensor (UP-Sense). It senses temperature, humidity, ambient light **and** water leak simultaneously, with **two leak channels**: onboard water pads (internal) and a **3.5 mm AUX external probe**. It signals leak capability via `leakSettings.{isInternalEnabled,isExternalEnabled}` and reports detections on `leakDetectedAt` (internal) and **`externalLeakDetectedAt`** (external), while `mountType` stays `none`.

The current `Sensor` model is built around the universal sensor's single-role `mount_type` selector:

```python
def is_leak_sensor_enabled(self) -> bool:
    return self.mount_type is MountType.LEAK
def is_leak_detected(self) -> bool:
    return self.leak_detected_at is not None
```

So on an Environmental Sensor `is_leak_sensor_enabled` is always `False` (mount is `none`), the leak entity is disabled/unavailable, and `externalLeakDetectedAt` is not modeled at all.

### Real-device evidence (bootstrap, `USL-Environmental-US`, fw 1.2.0)

```
mountType: "none"
leakSettings: { "isInternalEnabled": true, "isExternalEnabled": true }
leakDetectedAt: <set when onboard pads wet>
externalLeakDetectedAt: <set when 3.5mm AUX probe wet>
```

Across 9 units the deployment role (leak vs climate) is determined entirely by `leakSettings`, never by `mount_type`. A live leak test confirmed the field mapping: onboard pads → `leakDetectedAt`; AUX probe → `externalLeakDetectedAt` (independent fields).

## Changes

- New `SensorLeakSettings` (`is_internal_enabled` / `is_external_enabled`).
- `Sensor`: add `external_leak_detected_at` and `leak_settings`; mark `externalLeakDetectedAt` read-only.
- `is_leak_sensor_enabled` honors `leak_settings` **in addition to** `mount_type is LEAK` (legacy behavior preserved).
- `is_leak_detected` also considers `external_leak_detected_at`; add `is_internal_leak_detected` / `is_external_leak_detected` so consumers can expose the two channels separately if desired.

All new fields are optional with defaults, so legacy sensor payloads (no `leakSettings`) parse unchanged.

## Tests

Added property tests in `tests/data/test_sensor.py` (legacy `mount_type` path, `leak_settings` enablement matrix, and internal/external detection). Full `tests/data/test_sensor.py` passes (83 passed), so the existing `sample_sensor.json` still parses with the new fields.

## Open question for maintainers

Happy to also contribute an anonymized `USL-Environmental-US` sample fixture, and/or to keep `is_leak_detected` as the combined channel vs. exposing internal/external as two separate leak entities — let me know your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sensors that can report both internal and external leak detection.
  * Leak status can now be tracked separately for internal and external channels.
  * Leak-enabled behavior now works with newer sensor settings while preserving legacy sensor behavior.

* **Bug Fixes**
  * Leak detection now considers both standard and external leak timestamps when reporting overall leak state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->