### PR TITLE
ci(spec): fetch the openapi spec from the developer portal and re-enable the cron

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -5,12 +5,13 @@ name: Spec conformance
 # The expensive validation runs at most ONCE per Protect release: the daily cron
 # only queries the firmware-latest API (seconds, no download) and short-circuits
 # while the validated version is current or a drift issue is already open. The
-# spec (~74 MB deb) is fetched ephemerally and never committed or uploaded.
+# spec (~400 KB, from the developer portal) is fetched ephemerally and never
+# committed or uploaded.
 
 on:
-  # schedule disabled: deb download (fw-download.ubnt.com) returns 403 from
-  # GitHub-hosted runners (datacenter IP block). Re-enable once a direct spec
-  # download or self-hosted runner is in place.
+  schedule:
+    # Daily at 06:17 UTC. Cheap until a release actually drifts.
+    - cron: "17 6 * * *"
   workflow_dispatch:
     inputs:
       version:
@@ -85,7 +86,7 @@ jobs:
           fi
 
       # Step 3: known drift — an issue for this version already exists. Exit BEFORE
-      # downloading the deb so steady-state and known-drift days never fetch.
+      # downloading the spec so steady-state and known-drift days never fetch.
       - name: Short-circuit if drift issue already open
         id: known
         if: steps.steady.outputs.skip != 'true'
@@ -101,7 +102,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Step 4a: fetch the spec (~74 MB) and validate — only when drift is new.
+      # Step 4a: fetch the spec (~400 KB) and validate — only when drift is new.
       - name: Install dependencies
         if: steps.steady.outputs.skip != 'true' && steps.known.outputs.skip != 'true'
         run: poetry install --all-extras

--- a/scripts/fetch_openapi.py
+++ b/scripts/fetch_openapi.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """
-Fetch the UniFi Protect integration OpenAPI spec from the official deb package.
+Fetch the UniFi Protect integration OpenAPI spec.
+
+Primary source is Ubiquiti's developer portal
+(https://developer.ui.com/protect/), which serves the spec as a small JSON
+document per version. The official deb package remains available as a
+fallback via ``--from-deb``.
 
 Writes openapi/integration.json (gitignored).  Requires only stdlib.
 """
@@ -10,31 +15,41 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import re
 import sys
 import tarfile
+import urllib.error
 import urllib.request
 from pathlib import Path
 
 FIRMWARE_API = "https://fw-update.ubnt.com/api/v2/firmware-latest"
+PORTAL_INDEX = "https://developer.ui.com/protect/"
+PORTAL_SPEC = "https://developer.ui.com/protect/v{version}/openapi.json"
 SPEC_MEMBER = "./usr/share/unifi-protect/app/fixtures/integration/openapi.json"
 DEFAULT_OUTPUT = Path(__file__).resolve().parent.parent / "openapi" / "integration.json"
 
 
-def fetch_spec(version: str | None = None, output: Path = DEFAULT_OUTPUT) -> None:
-    """Download the unifi-protect deb and extract the integration OpenAPI spec."""
-    url, ver = _get_download_url(version)
+def fetch_spec(
+    version: str | None = None,
+    output: Path = DEFAULT_OUTPUT,
+    *,
+    from_deb: bool = False,
+) -> None:
+    """Fetch the integration OpenAPI spec and write it to ``output``."""
+    deb_url, ver = _query_firmware(version)
     print(f"unifi-protect {ver}", file=sys.stderr)
-    print(f"Downloading (~74 MB): {url}", file=sys.stderr)
 
-    with urllib.request.urlopen(url, timeout=60) as resp:  # noqa: S310
-        deb_bytes = resp.read()
+    spec_bytes = _fetch_from_deb(deb_url) if from_deb else _fetch_from_portal(ver)
 
-    print("Extracting spec …", file=sys.stderr)
-    spec_bytes = _extract_from_deb(deb_bytes)
+    spec = json.loads(spec_bytes)
+    # The portal spec carries a placeholder ``info.version`` ("0.0.0"); the
+    # real version only lives in the URL. Stamp it so consumers can trust it.
+    if spec.get("info", {}).get("version") in (None, "0.0.0"):
+        spec.setdefault("info", {})["version"] = ver.removeprefix("v")
+        spec_bytes = json.dumps(spec, indent=2).encode() + b"\n"
 
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_bytes(spec_bytes)
-    spec = json.loads(spec_bytes)
     print(
         f"Written {output}  "
         f"(version {spec['info']['version']}, "
@@ -43,8 +58,49 @@ def fetch_spec(version: str | None = None, output: Path = DEFAULT_OUTPUT) -> Non
     )
 
 
-def _get_download_url(version: str | None) -> tuple[str, str]:
-    """Return (download_url, version_string) for the requested protect version."""
+def _fetch_from_portal(version: str) -> bytes:
+    """Download the spec from the developer portal (~400 KB)."""
+    url = PORTAL_SPEC.format(version=version.removeprefix("v"))
+    print(f"Downloading: {url}", file=sys.stderr)
+    request = urllib.request.Request(url)  # noqa: S310
+    try:
+        with urllib.request.urlopen(request, timeout=60) as resp:  # noqa: S310
+            if "json" not in resp.headers.get("Content-Type", ""):
+                raise RuntimeError(f"Unexpected content type from {url}")
+            return resp.read()
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+            raise RuntimeError(
+                f"No spec for version {version} on the developer portal; "
+                "see --list for published versions or retry with --from-deb"
+            ) from err
+        raise
+
+
+def _fetch_from_deb(url: str) -> bytes:
+    """Download the unifi-protect deb (~74 MB) and extract the spec."""
+    print(f"Downloading (~74 MB): {url}", file=sys.stderr)
+    with urllib.request.urlopen(url, timeout=60) as resp:  # noqa: S310
+        deb_bytes = resp.read()
+    print("Extracting spec …", file=sys.stderr)
+    return _extract_from_deb(deb_bytes)
+
+
+def list_versions() -> list[str]:
+    """Return the spec versions published on the developer portal, newest first."""
+    request = urllib.request.Request(PORTAL_INDEX)  # noqa: S310
+    with urllib.request.urlopen(request, timeout=60) as resp:  # noqa: S310
+        html = resp.read().decode(errors="replace")
+    # The portal is a Next.js app; the version picker's data is embedded in
+    # the page payload as an escaped JSON array of {"version": "vX.Y.Z"}.
+    match = re.search(r'versions\\":\[(.*?)\]', html)
+    if match is None:
+        raise RuntimeError(f"Could not find the version list on {PORTAL_INDEX}")
+    return re.findall(r"v(\d+\.\d+\.\d+)", match.group(1))
+
+
+def _query_firmware(version: str | None) -> tuple[str, str]:
+    """Return (deb_download_url, version_string) for the requested protect version."""
     params = [
         "filter=eq~~product~~unifi-protect",
         "filter=eq~~platform~~uos-deb11-arm64",
@@ -116,11 +172,23 @@ if __name__ == "__main__":
     parser.add_argument(
         "--print-version",
         action="store_true",
-        help="Print the resolved version to stdout and exit (no ~74 MB download)",
+        help="Print the resolved version to stdout and exit (no download)",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List spec versions published on the developer portal and exit",
+    )
+    parser.add_argument(
+        "--from-deb",
+        action="store_true",
+        help="Extract the spec from the official deb (~74 MB) instead of the portal",
     )
     args = parser.parse_args()
-    if args.print_version:
-        _, ver = _get_download_url(args.version)
+    if args.list:
+        print("\n".join(list_versions()))
+    elif args.print_version:
+        _, ver = _query_firmware(args.version)
         print(ver)
     else:
-        fetch_spec(args.version, args.output)
+        fetch_spec(args.version, args.output, from_deb=args.from_deb)


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/uilibs/uiprotect/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Ubiquiti now publishes the Integration OpenAPI spec directly on the developer
portal (`https://developer.ui.com/protect/v{version}/openapi.json`), so
`scripts/fetch_openapi.py` no longer needs to download and unpack the ~74 MB
deb — the portal serves the same document as ~400 KB of JSON.

- Portal is the default source; `--from-deb` keeps the old deb-extraction path
  as a fallback. `--list` prints the versions published on the portal (back to
  5.3.48). `--print-version` semantics are unchanged (firmware-latest API stays
  the authoritative release resolver).
- The portal spec carries a placeholder `info.version` ("0.0.0" — the real
  version only lives in the URL), so the script stamps the resolved version
  into the written file to match the deb convention.
- Content parity verified for 7.1.83 against the deb-extracted spec: `paths`,
  `components`, `tags` and `security` are byte-identical; only `info` and the
  cosmetic `servers` block differ.
- **Re-enables the daily spec-conformance cron** that was disabled because
  fw-download.ubnt.com 403s GitHub-hosted runners — the portal fetch is exactly
  the "direct spec download" the disable note was waiting for. Verified
  locally: fetch + `validate_spec.py` pass green for both 7.1.83 and 7.1.87
  (the current release), so the first scheduled run should open the marker-bump
  PR for v7.1.87.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A (network-fetch script; the spec-consuming logic is covered by the existing validate_spec tests, which pass against a portal-fetched spec)
- [x] Documentation has been updated to reflect this change
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OpenAPI specification validation now runs automatically every day.
  * Specification retrieval is faster and more lightweight by using the developer portal by default.
  * Added an optional fallback for retrieving specifications from official package files.
  * Added a command to list available specification versions.
  * Downloaded specifications now receive a version when one is missing or unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->