### PR TITLE
fix(api): give the private websocket a heartbeat

### DIFF
--- a/src/uiprotect/api.py
+++ b/src/uiprotect/api.py
@@ -293,9 +293,15 @@ PUBLIC_RESYNC_MIN_INTERVAL = 10.0
 # cadence, so without keepalive the idle timer drops it every cycle. A ping
 # elicits a server pong — an upstream read that resets the proxy timer — and
 # also gives aiohttp liveness detection. 180s keeps ~3 touches per 10-min
-# window so a single lost frame does not trip the timeout. The private WS is
-# chatty and left unchanged.
+# window so a single lost frame does not trip the timeout.
 PUBLIC_WS_HEARTBEAT = 180.0
+
+# Same keepalive for the private WS. Traffic volume is not liveness: when the
+# path drops without a close frame — a switch/controller reboot mid-stream —
+# ``receive()`` blocks forever on the half-open socket, so the state stays
+# CONNECTED and the reconnect loop never runs. A ping is the only thing that
+# fails on a dead peer.
+PRIVATE_WS_HEARTBEAT = 180.0
 
 # Max concurrent RTSPS-stream fetches issued while priming cameras in
 # ``update_public``. Bounds the GET fan-out so a large install does not fire
@@ -584,6 +590,7 @@ class BaseApiClient:
                 verify=self._verify_ssl,
                 timeout=self._ws_timeout,
                 receive_timeout=self._ws_receive_timeout,
+                heartbeat=PRIVATE_WS_HEARTBEAT,
             )
         return self._private_websocket
 

--- a/tests/test_api_ws_public.py
+++ b/tests/test_api_ws_public.py
@@ -10,7 +10,11 @@ import aiohttp
 import orjson
 import pytest
 
-from uiprotect.api import PUBLIC_WS_HEARTBEAT, BaseApiClient
+from uiprotect.api import (
+    PRIVATE_WS_HEARTBEAT,
+    PUBLIC_WS_HEARTBEAT,
+    BaseApiClient,
+)
 from uiprotect.data import NvrArmModeStatus, PublicBootstrap, PublicNVR
 from uiprotect.data.websocket import WSAction, WSSubscriptionMessage
 from uiprotect.exceptions import NotAuthorized
@@ -780,15 +784,15 @@ async def test_get_devices_websocket(
 
 
 @pytest.mark.asyncio()
-async def test_public_websockets_use_heartbeat(
+async def test_websockets_use_heartbeat(
     protect_client_no_debug: ProtectApiClient,
 ) -> None:
-    """Both public WS keep the nginx tunnel alive with a heartbeat; private WS does not."""
+    """Every WS is created with a keepalive heartbeat."""
     protect_client = protect_client_no_debug
 
     assert protect_client._get_events_websocket().heartbeat == PUBLIC_WS_HEARTBEAT
     assert protect_client._get_devices_websocket().heartbeat == PUBLIC_WS_HEARTBEAT
-    assert protect_client._get_websocket().heartbeat is None
+    assert protect_client._get_websocket().heartbeat == PRIVATE_WS_HEARTBEAT
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
### Description of change

The private WS is constructed without `heartbeat=`, on the reasoning recorded next to `PUBLIC_WS_HEARTBEAT`: *"The private WS is chatty and left unchanged."* Traffic volume isn't liveness, though — it only tells you the peer **was** alive. When the path drops without a close frame, nothing is left to notice:

- `receive()` blocks indefinitely on the half-open socket (`ws_receive_timeout` defaults to `None`)
- no ping is ever sent, so nothing probes the dead peer
- `_websocket_inner_loop` never breaks, so the outer loop never reconnects
- the state stays `CONNECTED`, so `state_callback` consumers are never told anything changed

The result is a permanently silent stream with no error and no reconnect, indistinguishable from an idle system.

Observed in the wild: a network switch reboot severed the path mid-stream and the private WS stayed silent for **two days**, until the connection was recreated by hand. The two **public** WS channels — same host, same network event, same window — detected the dead peer via their heartbeat and reconnected normally. That contrast is the evidence for this change.

This extends rather than reverses #1071: that PR added the heartbeat to keep the quiet public channels from tripping the nginx `proxy_read_timeout` idle timer, and "the private WS is chatty" is correct reasoning for *that* problem — a chatty channel never idles long enough to trip nginx. It just doesn't address liveness, which is a separate failure mode.

`PRIVATE_WS_HEARTBEAT` is kept separate from `PUBLIC_WS_HEARTBEAT` deliberately: the public value is derived from the nginx `proxy_read_timeout` (≈3 touches per 10-minute window), while this one is a dead-peer detection-latency choice that nothing about the proxy constrains. They coincide at 180s today but aren't the same constraint, so collapsing them would couple two independent knobs. Happy to merge them into a single `WS_HEARTBEAT` if you'd prefer.

Verified with the full suite (`2344 passed, 6 skipped`), `ruff check` / `ruff format` clean (the 7 pre-existing `PLR0917`/`RUF036` findings in `api.py` are unchanged from `main`), and `mypy src/uiprotect/api.py` clean.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/uilibs/uiprotect/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` — N/A, no existing issue
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change — N/A
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)