### PR TITLE
fix(stream): log errors from non-blocking talkback

### DIFF
--- a/src/uiprotect/stream.py
+++ b/src/uiprotect/stream.py
@@ -142,8 +142,8 @@ class TalkbackStream:
 
     __slots__ = (
         "_error",
-        "_raise_error",
         "_lock",
+        "_raise_error",
         "_stop_event",
         "_thread",
         "camera",

--- a/src/uiprotect/stream.py
+++ b/src/uiprotect/stream.py
@@ -142,6 +142,7 @@ class TalkbackStream:
 
     __slots__ = (
         "_error",
+        "_raise_error",
         "_lock",
         "_stop_event",
         "_thread",
@@ -178,6 +179,7 @@ class TalkbackStream:
         self._thread: threading.Thread | None = None
         self._lock = asyncio.Lock()
         self._error: BaseException | None = None
+        self._raise_error = False
 
     async def __aenter__(self) -> Self:
         """Start streaming when entering async context."""
@@ -301,12 +303,19 @@ class TalkbackStream:
         if self._stop_event.is_set():
             return
         self._error = None
+        self._raise_error = raise_if_running
         self._thread = threading.Thread(
-            target=self._stream_audio_sync,
+            target=self._run_stream,
             name="TalkbackStream",
             daemon=True,
         )
         self._thread.start()
+
+    def _run_stream(self) -> None:
+        """Run the stream and report errors when no caller will collect them."""
+        self._stream_audio_sync()
+        if self._error is not None and not self._raise_error:
+            _LOGGER.error("Talkback streaming failed: %s", self._error)
 
     async def _wait_for_thread(self) -> None:
         """Wait for the thread to complete without blocking the event loop."""

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -518,7 +518,9 @@ async def test_start_logs_stream_error(caplog, mock_camera: Mock, audio_file: st
         while stream.is_running:
             await asyncio.sleep(0)
 
-    assert "Talkback streaming failed: Unsupported codec: unsupported_codec" in caplog.text
+    assert (
+        "Talkback streaming failed: Unsupported codec: unsupported_codec" in caplog.text
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -517,6 +517,7 @@ async def test_start_logs_stream_error(caplog, mock_camera: Mock, audio_file: st
         await stream.start()
         while stream.is_running:
             await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
     assert (
         "Talkback streaming failed: Unsupported codec: unsupported_codec" in caplog.text

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, Mock, patch
@@ -502,6 +503,22 @@ async def test_run_until_complete_unsupported_codec(mock_camera: Mock, audio_fil
     stream = TalkbackStream(mock_camera, audio_file, session)
     with pytest.raises(StreamError, match="Unsupported codec"):
         await stream.run_until_complete()
+
+
+@pytest.mark.asyncio
+async def test_start_logs_stream_error(caplog, mock_camera: Mock, audio_file: str):
+    session = TalkbackSession(
+        url="rtp://192.168.1.100:7004",
+        codec="unsupported_codec",
+        sampling_rate=24000,
+    )
+    stream = TalkbackStream(mock_camera, audio_file, session)
+    with caplog.at_level(logging.ERROR, logger="uiprotect.stream"):
+        await stream.start()
+        while stream.is_running:
+            await asyncio.sleep(0)
+
+    assert "Talkback streaming failed: Unsupported codec: unsupported_codec" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Issue

Closes #1185.

## Background

Non-blocking talkback streams store codec, input, and FFmpeg failures but never report them because no caller consumes the stored error.

## Changes

- Track whether the caller will collect a stream error.
- Log stored errors once from the worker thread for non-blocking starts.
- Preserve the existing exception behavior for blocking `run_until_complete()` calls.
- Add a regression test for the non-blocking error path.

## Compatibility

Blocking callers continue to receive the same `StreamError` exceptions. Non-blocking callers now receive an error log for failures that were previously silent.

## Tests

- `python -m py_compile src/uiprotect/stream.py tests/test_stream.py` — passed.
- `poetry run pytest tests/test_stream.py -q` — not completed because dependency installation failed while downloading `av` from PyPI (`ReadTimeoutError`); the initial run also reported missing `aiozoneinfo`.
- `git diff --check` — passed.

## Limitations

The full pytest suite and pre-commit checks could not run because the environment could not complete the locked dependency installation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Talkback streaming failures are now logged clearly when they cannot be returned directly to the caller.
  * Improved error handling for unsupported audio codecs, making failures easier to identify.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->